### PR TITLE
Fixes #335 - Added scoped table name to "deleted_at" where clause. This ...

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -168,7 +168,8 @@ func (scope *Scope) whereSql() (sql string) {
 	var primaryCondiations, andConditions, orConditions []string
 
 	if !scope.Search.Unscope && scope.HasColumn("DeletedAt") {
-		primaryCondiations = append(primaryCondiations, "(deleted_at IS NULL OR deleted_at <= '0001-01-02')")
+		sql := fmt.Sprintf("(%v.deleted_at IS NULL OR %v.deleted_at <= '0001-01-02')", scope.QuotedTableName(), scope.QuotedTableName())
+		primaryCondiations = append(primaryCondiations, sql)
 	}
 
 	if !scope.PrimaryKeyZero() {


### PR DESCRIPTION
...ensures it works when the deleted_at column is ambiguous, for example, during a join.