### PR TITLE
Ensure identifiers are quoted for `RETURNING` and `DROP INDEX` statements.

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -66,7 +66,7 @@ func (s *postgres) PrimaryKeyTag(value reflect.Value, size int) string {
 }
 
 func (s *postgres) ReturningStr(tableName, key string) string {
-	return fmt.Sprintf("RETURNING \"%v\".%v", tableName, key)
+	return fmt.Sprintf("RETURNING %v.%v", s.Quote(tableName), s.Quote(key))
 }
 
 func (s *postgres) SelectFromDummyTable() string {
@@ -97,7 +97,7 @@ func (s *postgres) HasColumn(scope *Scope, tableName string, columnName string) 
 }
 
 func (s *postgres) RemoveIndex(scope *Scope, indexName string) {
-	scope.Raw(fmt.Sprintf("DROP INDEX %v", indexName)).Exec()
+	scope.Raw(fmt.Sprintf("DROP INDEX %v", s.Quote(indexName))).Exec()
 }
 
 var hstoreType = reflect.TypeOf(Hstore{})


### PR DESCRIPTION
Ensure identifiers are quoted for `RETURNING` and `DROP INDEX` statements.

Before:

    INSERT INTO "public_key" ("key","sha256","md5","created_at")
        VALUES ('{{something}}','2015-01-13 15:09:43.866500097 -0800 PST')
        RETURNING public_key.id

Error:

    pq: Function id is not defined

After:

    INSERT INTO "public_key" ("key","sha256","md5","created_at")
        VALUES ('{{something}}','2015-01-13 15:09:43.866500097 -0800 PST')
        RETURNING "public_key"."id"