### PR TITLE
support embedded structs if they support the sql.Valuer interface

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -2,6 +2,7 @@ package gorm
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -30,7 +31,11 @@ func Create(scope *Scope) {
 					continue
 				}
 				columns = append(columns, scope.Quote(field.DBName))
-				sqls = append(sqls, scope.AddToVars(field.Field.Interface()))
+				val := field.Field
+				if val.Kind() == reflect.Struct {
+					val = val.Addr()
+				}
+				sqls = append(sqls, scope.AddToVars(val.Interface()))
 			}
 		}
 


### PR DESCRIPTION
With this change, a struct supporting the `sql.Valuer` interface can be used as a field in a record. I'm using this to embed structs as JSON fields in postgres.

This is how I'm using it:

```go
// this is the model that gets inserted into the database
type Model struct {
	Id         uuid.UUID        `json:"id"`
	Meta       Meta             `json:"meta"`
	Name       string           `json:"name"`
	Active     bool             `json:"active"`
}

// this is a composite field type, representing some structured data
type Meta struct {
	VersionId   int       `json:"versionId"`
	LastUpdated time.Time `json:"lastUpdated"`
}

func (m *Meta) Value() (driver.Value, error) {
	return json.Marshal(m)
}

func (m *Meta) Scan(src interface{}) error {
	if data, ok := src.([]byte); !ok {
		return ErrInvalidInput
	} else {
		return json.Unmarshal(data, m)
	}
}
```

Here's my schema:

```sql
create table models (
  id uuid,
  meta json,
  name text,
  active boolean
);
```

And here's proof that it works:

```
                  id                  |                                 meta                                 |           name           | active
--------------------------------------+----------------------------------------------------------------------+--------------------------+--------
 aa67a444-0dfe-4e03-b547-727a33ea3c4c | {"versionId":10,"lastUpdated":"2015-01-22T18:13:49.770372047+11:00"} | St God Memorial Hospital | t
```