### PR TITLE
reverse commit, which produces a bug

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -300,7 +300,7 @@ func (s *Scope) joinsSql() string {
 
 func (scope *Scope) prepareQuerySql() {
 	if scope.Search.Raw {
-		scope.Raw(strings.TrimRight(strings.TrimLeft(scope.CombinedConditionSql(), "WHERE ("), ")"))
+		scope.Raw(strings.TrimLeft(scope.CombinedConditionSql(), "WHERE "))
 	} else {
 		scope.Raw(fmt.Sprintf("SELECT %v %v FROM %v %v", scope.topSql(), scope.selectSql(), scope.QuotedTableName(), scope.CombinedConditionSql()))
 	}


### PR DESCRIPTION
the latest commit to master caused a problem with raw queries. ```syntax error at or near ")"```

It changed the query

```
SELECT translation
    , translatable.technical_name as translatable
    , language.iso_639_1 as language
    , locale.full_locale as locale
    , translatable.id as translatable_id
FROM translation
JOIN translatable ON translatable_id = translatable.id
LEFT JOIN language ON language_id = language.id
LEFT JOIN locale ON locale_id = locale.id
WHERE (language.iso_639_1 = $1 OR locale.full_locale = $1)
AND translatable.%s = $2`
```

to

```
SELECT translation
    , translatable.technical_name as translatable
    , language.iso_639_1 as language
    , locale.full_locale as locale
    , translatable.id as translatable_id
FROM translation
JOIN translatable ON translatable_id = translatable.id
LEFT JOIN language ON language_id = language.id
LEFT JOIN locale ON locale_id = locale.id
WHERE (language.iso_639_1 = $1 OR locale.full_locale = $1)
AND translatable.id = $2) LIMIT 1
```