### PR TITLE
check for IsScanner on slices

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -351,7 +351,9 @@ func (scope *Scope) fieldFromStruct(fieldStruct reflect.StructField, withRelatio
 		case reflect.Slice:
 			typ = typ.Elem()
 
-			if (typ.Kind() == reflect.Struct) && withRelation {
+			if field.IsScanner() {
+				field.IsNormal = true
+			} else if (typ.Kind() == reflect.Struct) && withRelation {
 				if foreignKey == "" {
 					foreignKey = scopeTyp.Name() + "Id"
 				}

--- a/slice_test.go
+++ b/slice_test.go
@@ -1,0 +1,70 @@
+package gorm_test
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"testing"
+)
+
+func TestScannableSlices(t *testing.T) {
+	if err := DB.AutoMigrate(&RecordWithSlice{}).Error; err != nil {
+		t.Errorf("Should create table with slice values correctly: %s", err)
+	}
+
+	r1 := RecordWithSlice{
+		Strings: ExampleStringSlice{"a", "b", "c"},
+		Structs: ExampleStructSlice{
+			{"name1", "value1"},
+			{"name2", "value2"},
+		},
+	}
+
+	if err := DB.Save(&r1).Error; err != nil {
+		t.Errorf("Should save record with slice values")
+	}
+
+	var r2 RecordWithSlice
+
+	if err := DB.Find(&r2).Error; err != nil {
+		t.Errorf("Should fetch record with slice values")
+	}
+
+	if len(r2.Strings) != 3 || r2.Strings[0] != "a" || r2.Strings[1] != "b" || r2.Strings[2] != "c" {
+		t.Errorf("Should have serialised and deserialised a string array")
+	}
+
+	if len(r2.Structs) != 2 || r2.Structs[0].Name != "name1" || r2.Structs[0].Value != "value1" || r2.Structs[1].Name != "name2" || r2.Structs[1].Value != "value2" {
+		t.Errorf("Should have serialised and deserialised a struct array")
+	}
+}
+
+type RecordWithSlice struct {
+	ID      uint64
+	Strings ExampleStringSlice `sql:"type:text"`
+	Structs ExampleStructSlice `sql:"type:text"`
+}
+
+type ExampleStringSlice []string
+
+func (l ExampleStringSlice) Value() (driver.Value, error) {
+	return json.Marshal(l)
+}
+
+func (l *ExampleStringSlice) Scan(input interface{}) error {
+	return json.Unmarshal(input.([]byte), l)
+}
+
+type ExampleStruct struct {
+	Name  string
+	Value string
+}
+
+type ExampleStructSlice []ExampleStruct
+
+func (l ExampleStructSlice) Value() (driver.Value, error) {
+	return json.Marshal(l)
+}
+
+func (l *ExampleStructSlice) Scan(input interface{}) error {
+	return json.Unmarshal(input.([]byte), l)
+}


### PR DESCRIPTION
I've got a list type that I want to serialise to a single value (included below). With this change, gorm will check to see if a slice can be treated as a value, just as happens with structs below. The column in the database is like `create table x (identifiers jsonb[])`.

```go
type Identifier struct {
	Use      Code          `json:"use"`
	Label    string        `json:"label"`
	System   URI           `json:"system"`
	Value    string        `json:"value"`
	Period   *Period       `json:"period"`
	Assigner *Organization `json:"assigner"`
}

type IdentifierList []Identifier

func (i IdentifierList) Value() (driver.Value, error) {
	bits := []string{}

	for _, v := range i {
		if d, err := json.Marshal(v); err != nil {
			return nil, err
		} else {
			bits = append(bits, strconv.Quote(string(d)))
		}
	}

	v := []byte("{" + strings.Join(bits, ",") + "}")

	return v, nil
}

func (i *IdentifierList) Scan(input interface{}) error {
	b, ok := input.([]byte)
	if !ok {
		return ErrInvalidInput
	}

	var bits []string
	if err := json.Unmarshal([]byte("["+string(b[1:len(b)-1])+"]"), &bits); err != nil {
		return err
	}

	for _, s := range bits {
		var v Identifier
		if err := json.Unmarshal([]byte(s), &v); err != nil {
			return err
		}

		*i = append(*i, v)
	}

	return nil
}
```