### PR TITLE
Postgres driver updated for FoundationDB auto-migration compatibility.

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -91,14 +91,15 @@ func (s *postgres) RemoveIndex(scope *Scope, indexName string) {
 }
 
 func (s *postgres) HasIndex(scope *Scope, tableName string, indexName string) bool {
-	// Determine whehter the pg_indexes talbe is
-	detect := []int{} //make([]int, 2) // If detect[0] == 1 then we have postgres, else if detect[1] == 1 then we have detectationDB.
-	scope.NewDB().Raw(`SELECT count(*) "detect" FROM INFORMATION_SCHEMA.tables WHERE table_name = 'pg_indexes' UNION SELECT count(*) "detect" FROM INFORMATION_SCHEMA.tables WHERE table_name = 'indexes'`).Pluck("detect", &detect)
+	// Determine whether we're using a postgres db or foundation.
+	var isPg int
+	var isFdb int
+	scope.NewDB().Raw(`SELECT (SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = 'pg_indexes') "pg", (SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = 'indexes') "fdb"`).Row().Scan(&isPg, &isFdb)
 	var count int
 	var indexQuery string
-	if detect[0] == 1 { // Then we have postgres.
+	if isPg == 1 { // Then we have postgres.
 		indexQuery = "SELECT count(*) FROM pg_indexes WHERE tablename = ? AND indexname = ?"
-	} else if detect[1] == 1 { // Then we have FoundationDB.
+	} else if isFdb == 1 { // Then we have FoundationDB.
 		indexQuery = "SELECT count(*) FROM INFORMATION_SCHEMA.indexes WHERE table_schema = current_schema AND table_name = ? AND index_name = ?"
 	} else {
 		panic("unable to query for indexes, unrecognized database schema layout")

--- a/scope_private.go
+++ b/scope_private.go
@@ -3,7 +3,6 @@ package gorm
 import (
 	"database/sql"
 	"database/sql/driver"
-	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -360,7 +359,7 @@ func (scope *Scope) pluck(column string, value interface{}) *Scope {
 	dest := reflect.Indirect(reflect.ValueOf(value))
 	scope.Search.Select(column)
 	if dest.Kind() != reflect.Slice {
-		scope.Err(errors.New("results should be a slice"))
+		scope.Err(fmt.Errorf("results should be a slice, not %s", dest.Kind()))
 		return scope
 	}
 


### PR DESCRIPTION
    $ ./test_all.sh
    testing postgres...
    [info] replacing callback `create` from callback_test.go:94
    [info] removing callback `create` from callback_test.go:107
    `testdb` is not officially supported, running under compatibility mode.
    PASS
    ok  	gorm	1.364s
