### PR TITLE
Fix creation of composite unique indexes

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -570,7 +570,7 @@ func (scope *Scope) autoIndex() *Scope {
 			if name == "UNIQUE_INDEX" {
 				name = fmt.Sprintf("uix_%v_%v", scope.TableName(), field.DBName)
 			}
-			uniqueIndexes[name] = append(indexes[name], field.DBName)
+			uniqueIndexes[name] = append(uniqueIndexes[name], field.DBName)
 		}
 	}
 


### PR DESCRIPTION
Previously, specifying a struct like:

    type Foo struct {
    	Email        string    `sql:"unique_index:idx_email_agent"`
    	UserAgent    string    `sql:"unique_index:idx_email_agent"`
    }

…would result in an `idx_email_agent` index created over `user_agent`, excluding `email`.