### PR TITLE
FoundationDB dialect integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ import (
 )
 
 db, err := gorm.Open("postgres", "user=gorm dbname=gorm sslmode=disable")
+// db, err := gorm.Open("foundation", "dbname=gorm") // FoundationDB.
 // db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
 // db, err := gorm.Open("sqlite3", "/tmp/gorm.db")
 

--- a/dialect.go
+++ b/dialect.go
@@ -24,6 +24,8 @@ func NewDialect(driver string) Dialect {
 	switch driver {
 	case "postgres":
 		d = &postgres{}
+	case "foundation":
+		d = &foundation{}
 	case "mysql":
 		d = &mysql{}
 	case "sqlite3":

--- a/foundation.go
+++ b/foundation.go
@@ -1,0 +1,78 @@
+package gorm
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+type foundation struct {
+	commonDialect
+}
+
+func (foundation) BinVar(i int) string {
+	return fmt.Sprintf("$%v", i)
+}
+
+func (foundation) SupportLastInsertId() bool {
+	return false
+}
+
+func (foundation) SqlTag(value reflect.Value, size int, autoIncrease bool) string {
+	switch value.Kind() {
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
+		if autoIncrease {
+			return "serial"
+		}
+		return "int"
+	case reflect.Int64, reflect.Uint64:
+		if autoIncrease {
+			return "bigserial"
+		}
+		return "bigint"
+	case reflect.Float32, reflect.Float64:
+		return "double"
+	case reflect.String:
+		if size > 0 && size < 65532 {
+			return fmt.Sprintf("varchar(%d)", size)
+		}
+		return "clob"
+	case reflect.Struct:
+		if _, ok := value.Interface().(time.Time); ok {
+			return "datetime"
+		}
+	default:
+		if _, ok := value.Interface().([]byte); ok {
+			return "blob"
+		}
+	}
+	panic(fmt.Sprintf("invalid sql type %s (%s) for foundation", value.Type().Name(), value.Kind().String()))
+}
+
+func (f foundation) ReturningStr(tableName, key string) string {
+	return fmt.Sprintf("RETURNING %v.%v", f.Quote(tableName), key)
+}
+
+func (foundation) HasTable(scope *Scope, tableName string) bool {
+	var count int
+	scope.NewDB().Raw("SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_schema = current_schema AND table_type = 'TABLE' AND table_name = ?", tableName).Row().Scan(&count)
+	return count > 0
+}
+
+func (foundation) HasColumn(scope *Scope, tableName string, columnName string) bool {
+	var count int
+	scope.NewDB().Raw("SELECT count(*) FROM INFORMATION_SCHEMA.columns WHERE table_schema = current_schema AND table_name = ? AND column_name = ?", tableName, columnName).Row().Scan(&count)
+	return count > 0
+}
+
+func (f foundation) RemoveIndex(scope *Scope, indexName string) {
+	scope.NewDB().Exec(fmt.Sprintf("DROP INDEX %v", f.Quote(indexName)))
+}
+
+func (foundation) HasIndex(scope *Scope, tableName string, indexName string) bool {
+	var count int
+	scope.NewDB().Raw("SELECT count(*) FROM INFORMATION_SCHEMA.indexes WHERE table_schema = current_schema AND table_name = ? AND index_name = ?", tableName, indexName).Row().Scan(&count)
+	return count > 0
+}

--- a/join_table_handler.go
+++ b/join_table_handler.go
@@ -104,7 +104,7 @@ func (s JoinTableHandler) Add(db *DB, source1 interface{}, source2 interface{}) 
 
 	quotedTable := s.Table(db)
 	sql := fmt.Sprintf(
-		"INSERT INTO %v (%v) SELECT %v %v WHERE NOT EXISTS (SELECT * FROM %v WHERE %v);",
+		"INSERT INTO %v (%v) SELECT %v %v WHERE NOT EXISTS (SELECT * FROM %v WHERE %v)",
 		quotedTable,
 		strings.Join(assignColumns, ","),
 		strings.Join(binVars, ","),

--- a/main.go
+++ b/main.go
@@ -55,6 +55,9 @@ func Open(dialect string, args ...interface{}) (DB, error) {
 				driver = value
 				source = args[1].(string)
 			}
+			if driver == "foundation" {
+				driver = "postgres" // FoundationDB speaks a postgres-compatible protocol.
+			}
 			dbSql, err = sql.Open(driver, source)
 		case sqlCommon:
 			source = reflect.Indirect(reflect.ValueOf(value)).FieldByName("dsn").String()

--- a/scope_private.go
+++ b/scope_private.go
@@ -3,7 +3,6 @@ package gorm
 import (
 	"database/sql"
 	"database/sql/driver"
-	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -360,7 +359,7 @@ func (scope *Scope) pluck(column string, value interface{}) *Scope {
 	dest := reflect.Indirect(reflect.ValueOf(value))
 	scope.Search.Select(column)
 	if dest.Kind() != reflect.Slice {
-		scope.Err(errors.New("results should be a slice"))
+		scope.Err(fmt.Errorf("results should be a slice, not %s", dest.Kind()))
 		return scope
 	}
 

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,4 +1,4 @@
-dialects=("postgres" "mysql" "sqlite")
+dialects=("postgres" "foundation" "mysql" "sqlite")
 
 for dialect in "${dialects[@]}" ; do
     GORM_DIALECT=${dialect} go test


### PR DESCRIPTION
This is now ready for review.

For "test_all.sh", at first I wasn't sure about adding foundation, but ultimately I figured it was best to include it.

One interesting lesson I learned while implementing this dialect is that the FoundationDB `DATETIME` type does not support timezones.

The unit-tests are passing for me, he is the output:

    jay@jays-mba:~/go/src/github.com/jinzhu/gorm$ ./test_all.sh
    testing postgres...
    === RUN TestRegisterCallback
    --- PASS: TestRegisterCallback (0.00s)
    === RUN TestRegisterCallbackWithOrder
    --- PASS: TestRegisterCallbackWithOrder (0.00s)
    === RUN TestRegisterCallbackWithComplexOrder
    --- PASS: TestRegisterCallbackWithComplexOrder (0.00s)
    === RUN TestReplaceCallback
    [info] replacing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:94
    --- PASS: TestReplaceCallback (0.00s)
    === RUN TestRemoveCallback
    [info] removing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:107
    --- PASS: TestRemoveCallback (0.00s)
    === RUN TestCloneSearch
    --- PASS: TestCloneSearch (0.00s)
    === RUN TestHasOneAndHasManyAssociation
    --- PASS: TestHasOneAndHasManyAssociation (0.11s)
    === RUN TestRelated
    --- PASS: TestRelated (0.02s)
    === RUN TestManyToMany
    --- PASS: TestManyToMany (0.07s)
    === RUN TestForeignKey
    --- PASS: TestForeignKey (0.00s)
    === RUN TestRunCallbacks
    --- PASS: TestRunCallbacks (0.01s)
    === RUN TestCallbacksWithErrors
    --- PASS: TestCallbacksWithErrors (0.02s)
    === RUN TestCreate
    --- PASS: TestCreate (0.00s)
    === RUN TestCreateWithNoGORMPrimayKey
    --- PASS: TestCreateWithNoGORMPrimayKey (0.00s)
    === RUN TestCreateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestCreateWithNoStdPrimaryKeyAndDefaultValues (0.00s)
    === RUN TestAnonymousScanner
    --- PASS: TestAnonymousScanner (0.00s)
    === RUN TestAnonymousField
    --- PASS: TestAnonymousField (0.00s)
    === RUN TestSelectWithCreate
    --- PASS: TestSelectWithCreate (0.01s)
    === RUN TestOmitWithCreate
    --- PASS: TestOmitWithCreate (0.01s)
    === RUN TestCustomizeColumn
    --- PASS: TestCustomizeColumn (0.01s)
    === RUN TestCustomColumnAndIgnoredFieldClash
    --- PASS: TestCustomColumnAndIgnoredFieldClash (0.01s)
    === RUN TestDelete
    --- PASS: TestDelete (0.01s)
    === RUN TestInlineDelete
    --- PASS: TestInlineDelete (0.01s)
    === RUN TestSoftDelete
    --- PASS: TestSoftDelete (0.02s)
    === RUN TestSaveAndQueryEmbeddedStruct
    --- PASS: TestSaveAndQueryEmbeddedStruct (0.01s)
    === RUN TestJoinTable
    --- PASS: TestJoinTable (0.06s)
    === RUN TestExceptionsWithInvalidSql
    --- PASS: TestExceptionsWithInvalidSql (0.00s)
    === RUN TestSetTable
    --- PASS: TestSetTable (0.06s)
    === RUN TestHasTable
    --- PASS: TestHasTable (0.01s)
    === RUN TestTableName
    --- PASS: TestTableName (0.00s)
    === RUN TestSqlNullValue
    --- PASS: TestSqlNullValue (0.04s)
    === RUN TestTransaction
    --- PASS: TestTransaction (0.01s)
    === RUN TestRow
    --- PASS: TestRow (0.00s)
    === RUN TestRows
    --- PASS: TestRows (0.00s)
    === RUN TestScan
    --- PASS: TestScan (0.01s)
    === RUN TestRaw
    --- PASS: TestRaw (0.01s)
    === RUN TestGroup
    --- PASS: TestGroup (0.00s)
    === RUN TestJoins
    --- PASS: TestJoins (0.00s)
    === RUN TestHaving
    --- PASS: TestHaving (0.00s)
    === RUN TestTimeWithZone
    --- PASS: TestTimeWithZone (0.01s)
    === RUN TestHstore
    --- PASS: TestHstore (0.01s)
    === RUN TestSetAndGet
    --- PASS: TestSetAndGet (0.00s)
    === RUN TestCompatibilityMode
    `testdb` is not officially supported, running under compatibility mode.
    --- PASS: TestCompatibilityMode (0.00s)
    === RUN TestOpenExistingDB
    --- PASS: TestOpenExistingDB (0.01s)
    === RUN TestIndexes
    --- PASS: TestIndexes (0.09s)
    === RUN TestAutoMigration
    --- PASS: TestAutoMigration (0.05s)
    === RUN TestPointerFields
    --- PASS: TestPointerFields (0.01s)
    === RUN TestPolymorphic
    --- PASS: TestPolymorphic (0.04s)
    === RUN TestPreload
    --- PASS: TestPreload (0.05s)
    === RUN TestFirstAndLast
    --- PASS: TestFirstAndLast (0.01s)
    === RUN TestFirstAndLastWithNoStdPrimaryKey
    --- PASS: TestFirstAndLastWithNoStdPrimaryKey (0.00s)
    === RUN TestUIntPrimaryKey
    --- PASS: TestUIntPrimaryKey (0.00s)
    === RUN TestFindAsSliceOfPointers
    --- PASS: TestFindAsSliceOfPointers (0.01s)
    === RUN TestSearchWithPlainSQL
    --- PASS: TestSearchWithPlainSQL (0.01s)
    === RUN TestSearchWithStruct
    --- PASS: TestSearchWithStruct (0.02s)
    === RUN TestSearchWithMap
    --- PASS: TestSearchWithMap (0.01s)
    === RUN TestSearchWithEmptyChain
    --- PASS: TestSearchWithEmptyChain (0.01s)
    === RUN TestSelect
    --- PASS: TestSelect (0.00s)
    === RUN TestOrderAndPluck
    --- PASS: TestOrderAndPluck (0.01s)
    === RUN TestLimit
    --- PASS: TestLimit (0.01s)
    === RUN TestOffset
    --- PASS: TestOffset (0.05s)
    === RUN TestOr
    --- PASS: TestOr (0.01s)
    === RUN TestCount
    --- PASS: TestCount (0.01s)
    === RUN TestNot
    --- PASS: TestNot (0.06s)
    === RUN TestFillSmallerStruct
    --- PASS: TestFillSmallerStruct (0.01s)
    === RUN TestFindOrInitialize
    --- PASS: TestFindOrInitialize (0.01s)
    === RUN TestFindOrCreate
    --- PASS: TestFindOrCreate (0.02s)
    === RUN TestSelectWithEscapedFieldName
    --- PASS: TestSelectWithEscapedFieldName (0.01s)
    === RUN TestSelectWithVariables
    --- PASS: TestSelectWithVariables (0.00s)
    === RUN TestSelectWithArrayInput
    --- PASS: TestSelectWithArrayInput (0.01s)
    === RUN TestScopes
    --- PASS: TestScopes (0.01s)
    === RUN TestScannableSlices
    --- PASS: TestScannableSlices (0.02s)
    === RUN TestUpdate
    --- PASS: TestUpdate (0.02s)
    === RUN TestUpdateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestUpdateWithNoStdPrimaryKeyAndDefaultValues (0.01s)
    === RUN TestUpdates
    --- PASS: TestUpdates (0.02s)
    === RUN TestUpdateColumn
    --- PASS: TestUpdateColumn (0.01s)
    === RUN TestSelectWithUpdate
    --- PASS: TestSelectWithUpdate (0.02s)
    === RUN TestSelectWithUpdateWithMap
    --- PASS: TestSelectWithUpdateWithMap (0.02s)
    === RUN TestOmitWithUpdate
    --- PASS: TestOmitWithUpdate (0.02s)
    === RUN TestOmitWithUpdateWithMap
    --- PASS: TestOmitWithUpdateWithMap (0.02s)
    === RUN TestSelectWithUpdateColumn
    --- PASS: TestSelectWithUpdateColumn (0.01s)
    === RUN TestOmitWithUpdateColumn
    --- PASS: TestOmitWithUpdateColumn (0.01s)
    PASS
    ok  	github.com/jinzhu/gorm	1.550s
    testing foundation...
    === RUN TestRegisterCallback
    --- PASS: TestRegisterCallback (0.00s)
    === RUN TestRegisterCallbackWithOrder
    --- PASS: TestRegisterCallbackWithOrder (0.00s)
    === RUN TestRegisterCallbackWithComplexOrder
    --- PASS: TestRegisterCallbackWithComplexOrder (0.00s)
    === RUN TestReplaceCallback
    [info] replacing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:94
    --- PASS: TestReplaceCallback (0.00s)
    === RUN TestRemoveCallback
    [info] removing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:107
    --- PASS: TestRemoveCallback (0.00s)
    === RUN TestCloneSearch
    --- PASS: TestCloneSearch (0.00s)
    === RUN TestHasOneAndHasManyAssociation
    --- PASS: TestHasOneAndHasManyAssociation (0.41s)
    === RUN TestRelated
    --- PASS: TestRelated (0.08s)
    === RUN TestManyToMany
    --- PASS: TestManyToMany (0.35s)
    === RUN TestForeignKey
    --- PASS: TestForeignKey (0.00s)
    === RUN TestRunCallbacks
    --- PASS: TestRunCallbacks (0.06s)
    === RUN TestCallbacksWithErrors
    --- PASS: TestCallbacksWithErrors (0.10s)
    === RUN TestCreate
    --- PASS: TestCreate (0.04s)
    === RUN TestCreateWithNoGORMPrimayKey
    --- PASS: TestCreateWithNoGORMPrimayKey (0.01s)
    === RUN TestCreateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestCreateWithNoStdPrimaryKeyAndDefaultValues (0.04s)
    === RUN TestAnonymousScanner
    --- PASS: TestAnonymousScanner (0.02s)
    === RUN TestAnonymousField
    --- PASS: TestAnonymousField (0.03s)
    === RUN TestSelectWithCreate
    --- PASS: TestSelectWithCreate (0.06s)
    === RUN TestOmitWithCreate
    --- PASS: TestOmitWithCreate (0.05s)
    === RUN TestCustomizeColumn
    --- PASS: TestCustomizeColumn (0.17s)
    === RUN TestCustomColumnAndIgnoredFieldClash
    --- PASS: TestCustomColumnAndIgnoredFieldClash (0.11s)
    === RUN TestDelete
    --- PASS: TestDelete (0.11s)
    === RUN TestInlineDelete
    --- PASS: TestInlineDelete (0.08s)
    === RUN TestSoftDelete
    --- PASS: TestSoftDelete (0.33s)
    === RUN TestSaveAndQueryEmbeddedStruct
    --- PASS: TestSaveAndQueryEmbeddedStruct (0.04s)
    === RUN TestJoinTable
    --- PASS: TestJoinTable (0.59s)
    === RUN TestExceptionsWithInvalidSql
    --- PASS: TestExceptionsWithInvalidSql (0.02s)
    === RUN TestSetTable
    --- PASS: TestSetTable (0.38s)
    === RUN TestHasTable
    --- PASS: TestHasTable (0.12s)
    === RUN TestTableName
    --- PASS: TestTableName (0.00s)
    === RUN TestSqlNullValue
    --- PASS: TestSqlNullValue (0.15s)
    === RUN TestTransaction
    --- PASS: TestTransaction (0.03s)
    === RUN TestRow
    --- PASS: TestRow (0.05s)
    === RUN TestRows
    --- PASS: TestRows (0.05s)
    === RUN TestScan
    --- PASS: TestScan (0.06s)
    === RUN TestRaw
    --- PASS: TestRaw (0.08s)
    === RUN TestGroup
    --- PASS: TestGroup (0.00s)
    === RUN TestJoins
    --- PASS: TestJoins (0.02s)
    === RUN TestHaving
    --- PASS: TestHaving (0.01s)
    === RUN TestTimeWithZone
    --- PASS: TestTimeWithZone (0.05s)
    === RUN TestHstore
    --- SKIP: TestHstore (0.00s)
    	main_test.go:506:
    === RUN TestSetAndGet
    --- PASS: TestSetAndGet (0.00s)
    === RUN TestCompatibilityMode
    `testdb` is not officially supported, running under compatibility mode.
    --- PASS: TestCompatibilityMode (0.00s)
    === RUN TestOpenExistingDB
    --- PASS: TestOpenExistingDB (0.02s)
    === RUN TestIndexes
    --- PASS: TestIndexes (0.78s)
    === RUN TestAutoMigration
    --- PASS: TestAutoMigration (0.86s)
    === RUN TestPointerFields
    --- PASS: TestPointerFields (0.19s)
    === RUN TestPolymorphic
    --- PASS: TestPolymorphic (0.11s)
    === RUN TestPreload
    --- PASS: TestPreload (0.24s)
    === RUN TestFirstAndLast
    --- PASS: TestFirstAndLast (0.06s)
    === RUN TestFirstAndLastWithNoStdPrimaryKey
    --- PASS: TestFirstAndLastWithNoStdPrimaryKey (0.04s)
    === RUN TestUIntPrimaryKey
    --- PASS: TestUIntPrimaryKey (0.01s)
    === RUN TestFindAsSliceOfPointers
    --- PASS: TestFindAsSliceOfPointers (0.03s)
    === RUN TestSearchWithPlainSQL
    --- PASS: TestSearchWithPlainSQL (0.10s)
    === RUN TestSearchWithStruct
    --- PASS: TestSearchWithStruct (0.09s)
    === RUN TestSearchWithMap
    --- PASS: TestSearchWithMap (0.05s)
    === RUN TestSearchWithEmptyChain
    --- PASS: TestSearchWithEmptyChain (0.05s)
    === RUN TestSelect
    --- PASS: TestSelect (0.02s)
    === RUN TestOrderAndPluck
    --- PASS: TestOrderAndPluck (0.08s)
    === RUN TestLimit
    --- PASS: TestLimit (0.08s)
    === RUN TestOffset
    --- PASS: TestOffset (0.32s)
    === RUN TestOr
    --- PASS: TestOr (0.04s)
    === RUN TestCount
    --- PASS: TestCount (0.06s)
    === RUN TestNot
    --- PASS: TestNot (0.19s)
    === RUN TestFillSmallerStruct
    --- PASS: TestFillSmallerStruct (0.02s)
    === RUN TestFindOrInitialize
    --- PASS: TestFindOrInitialize (0.07s)
    === RUN TestFindOrCreate
    --- PASS: TestFindOrCreate (0.18s)
    === RUN TestSelectWithEscapedFieldName
    --- PASS: TestSelectWithEscapedFieldName (0.05s)
    === RUN TestSelectWithVariables
    --- PASS: TestSelectWithVariables (0.02s)
    === RUN TestSelectWithArrayInput
    --- PASS: TestSelectWithArrayInput (0.03s)
    === RUN TestScopes
    --- PASS: TestScopes (0.13s)
    === RUN TestScannableSlices
    --- PASS: TestScannableSlices (0.04s)
    === RUN TestUpdate
    --- PASS: TestUpdate (0.16s)
    === RUN TestUpdateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestUpdateWithNoStdPrimaryKeyAndDefaultValues (0.10s)
    === RUN TestUpdates
    --- PASS: TestUpdates (0.09s)
    === RUN TestUpdateColumn
    --- PASS: TestUpdateColumn (0.09s)
    === RUN TestSelectWithUpdate
    --- PASS: TestSelectWithUpdate (0.10s)
    === RUN TestSelectWithUpdateWithMap
    --- PASS: TestSelectWithUpdateWithMap (0.08s)
    === RUN TestOmitWithUpdate
    --- PASS: TestOmitWithUpdate (0.07s)
    === RUN TestOmitWithUpdateWithMap
    --- PASS: TestOmitWithUpdateWithMap (0.07s)
    === RUN TestSelectWithUpdateColumn
    --- PASS: TestSelectWithUpdateColumn (0.04s)
    === RUN TestOmitWithUpdateColumn
    --- PASS: TestOmitWithUpdateColumn (0.05s)
    PASS
    ok  	github.com/jinzhu/gorm	10.273s
    testing mysql...
    === RUN TestRegisterCallback
    --- PASS: TestRegisterCallback (0.00s)
    === RUN TestRegisterCallbackWithOrder
    --- PASS: TestRegisterCallbackWithOrder (0.00s)
    === RUN TestRegisterCallbackWithComplexOrder
    --- PASS: TestRegisterCallbackWithComplexOrder (0.00s)
    === RUN TestReplaceCallback
    [info] replacing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:94
    --- PASS: TestReplaceCallback (0.00s)
    === RUN TestRemoveCallback
    [info] removing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:107
    --- PASS: TestRemoveCallback (0.00s)
    === RUN TestCloneSearch
    --- PASS: TestCloneSearch (0.00s)
    === RUN TestHasOneAndHasManyAssociation
    --- PASS: TestHasOneAndHasManyAssociation (0.05s)
    === RUN TestRelated
    --- PASS: TestRelated (0.01s)
    === RUN TestManyToMany
    --- PASS: TestManyToMany (0.07s)
    === RUN TestForeignKey
    --- PASS: TestForeignKey (0.00s)
    === RUN TestRunCallbacks
    --- PASS: TestRunCallbacks (0.01s)
    === RUN TestCallbacksWithErrors
    --- PASS: TestCallbacksWithErrors (0.01s)
    === RUN TestCreate
    --- PASS: TestCreate (0.00s)
    === RUN TestCreateWithNoGORMPrimayKey
    --- PASS: TestCreateWithNoGORMPrimayKey (0.00s)
    === RUN TestCreateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestCreateWithNoStdPrimaryKeyAndDefaultValues (0.00s)
    === RUN TestAnonymousScanner
    --- PASS: TestAnonymousScanner (0.00s)
    === RUN TestAnonymousField
    --- PASS: TestAnonymousField (0.00s)
    === RUN TestSelectWithCreate
    --- PASS: TestSelectWithCreate (0.01s)
    === RUN TestOmitWithCreate
    --- PASS: TestOmitWithCreate (0.01s)
    === RUN TestCustomizeColumn
    --- PASS: TestCustomizeColumn (0.02s)
    === RUN TestCustomColumnAndIgnoredFieldClash
    --- PASS: TestCustomColumnAndIgnoredFieldClash (0.03s)
    === RUN TestDelete
    --- PASS: TestDelete (0.01s)
    === RUN TestInlineDelete
    --- PASS: TestInlineDelete (0.01s)
    === RUN TestSoftDelete
    --- PASS: TestSoftDelete (0.05s)
    === RUN TestSaveAndQueryEmbeddedStruct
    --- PASS: TestSaveAndQueryEmbeddedStruct (0.00s)
    === RUN TestJoinTable
    --- PASS: TestJoinTable (0.31s)
    === RUN TestExceptionsWithInvalidSql
    --- PASS: TestExceptionsWithInvalidSql (0.00s)
    === RUN TestSetTable
    --- PASS: TestSetTable (0.06s)
    === RUN TestHasTable
    --- PASS: TestHasTable (0.02s)
    === RUN TestTableName
    --- PASS: TestTableName (0.00s)
    === RUN TestSqlNullValue
    --- PASS: TestSqlNullValue (0.02s)
    === RUN TestTransaction
    --- PASS: TestTransaction (0.01s)
    === RUN TestRow
    --- PASS: TestRow (0.00s)
    === RUN TestRows
    --- PASS: TestRows (0.00s)
    === RUN TestScan
    --- PASS: TestScan (0.01s)
    === RUN TestRaw
    --- PASS: TestRaw (0.00s)
    === RUN TestGroup
    --- PASS: TestGroup (0.00s)
    === RUN TestJoins
    --- PASS: TestJoins (0.00s)
    === RUN TestHaving
    --- PASS: TestHaving (0.00s)
    === RUN TestTimeWithZone
    --- PASS: TestTimeWithZone (0.01s)
    === RUN TestHstore
    --- SKIP: TestHstore (0.00s)
    	main_test.go:506:
    === RUN TestSetAndGet
    --- PASS: TestSetAndGet (0.00s)
    === RUN TestCompatibilityMode
    `testdb` is not officially supported, running under compatibility mode.
    --- PASS: TestCompatibilityMode (0.00s)
    === RUN TestOpenExistingDB
    --- PASS: TestOpenExistingDB (0.00s)
    === RUN TestIndexes
    --- PASS: TestIndexes (0.12s)
    === RUN TestAutoMigration
    --- PASS: TestAutoMigration (0.14s)
    === RUN TestPointerFields
    --- PASS: TestPointerFields (0.02s)
    === RUN TestPolymorphic
    --- PASS: TestPolymorphic (0.06s)
    === RUN TestPreload
    --- PASS: TestPreload (0.04s)
    === RUN TestFirstAndLast
    --- PASS: TestFirstAndLast (0.01s)
    === RUN TestFirstAndLastWithNoStdPrimaryKey
    --- PASS: TestFirstAndLastWithNoStdPrimaryKey (0.00s)
    === RUN TestUIntPrimaryKey
    --- PASS: TestUIntPrimaryKey (0.00s)
    === RUN TestFindAsSliceOfPointers
    --- PASS: TestFindAsSliceOfPointers (0.01s)
    === RUN TestSearchWithPlainSQL
    --- PASS: TestSearchWithPlainSQL (0.01s)
    === RUN TestSearchWithStruct
    --- PASS: TestSearchWithStruct (0.01s)
    === RUN TestSearchWithMap
    --- PASS: TestSearchWithMap (0.00s)
    === RUN TestSearchWithEmptyChain
    --- PASS: TestSearchWithEmptyChain (0.01s)
    === RUN TestSelect
    --- PASS: TestSelect (0.00s)
    === RUN TestOrderAndPluck
    --- PASS: TestOrderAndPluck (0.01s)
    === RUN TestLimit
    --- PASS: TestLimit (0.01s)
    === RUN TestOffset
    --- PASS: TestOffset (0.04s)
    === RUN TestOr
    --- PASS: TestOr (0.00s)
    === RUN TestCount
    --- PASS: TestCount (0.00s)
    === RUN TestNot
    --- PASS: TestNot (0.03s)
    === RUN TestFillSmallerStruct
    --- PASS: TestFillSmallerStruct (0.00s)
    === RUN TestFindOrInitialize
    --- PASS: TestFindOrInitialize (0.01s)
    === RUN TestFindOrCreate
    --- PASS: TestFindOrCreate (0.01s)
    === RUN TestSelectWithEscapedFieldName
    --- PASS: TestSelectWithEscapedFieldName (0.00s)
    === RUN TestSelectWithVariables
    --- PASS: TestSelectWithVariables (0.00s)
    === RUN TestSelectWithArrayInput
    --- PASS: TestSelectWithArrayInput (0.00s)
    === RUN TestScopes
    --- PASS: TestScopes (0.00s)
    === RUN TestScannableSlices
    --- PASS: TestScannableSlices (0.02s)
    === RUN TestUpdate
    --- PASS: TestUpdate (0.01s)
    === RUN TestUpdateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestUpdateWithNoStdPrimaryKeyAndDefaultValues (0.01s)
    === RUN TestUpdates
    --- PASS: TestUpdates (0.01s)
    === RUN TestUpdateColumn
    --- PASS: TestUpdateColumn (0.01s)
    === RUN TestSelectWithUpdate
    --- PASS: TestSelectWithUpdate (0.01s)
    === RUN TestSelectWithUpdateWithMap
    --- PASS: TestSelectWithUpdateWithMap (0.01s)
    === RUN TestOmitWithUpdate
    --- PASS: TestOmitWithUpdate (0.01s)
    === RUN TestOmitWithUpdateWithMap
    --- PASS: TestOmitWithUpdateWithMap (0.01s)
    === RUN TestSelectWithUpdateColumn
    --- PASS: TestSelectWithUpdateColumn (0.01s)
    === RUN TestOmitWithUpdateColumn
    --- PASS: TestOmitWithUpdateColumn (0.01s)
    PASS
    ok  	github.com/jinzhu/gorm	1.797s
    testing sqlite3...
    === RUN TestRegisterCallback
    --- PASS: TestRegisterCallback (0.00s)
    === RUN TestRegisterCallbackWithOrder
    --- PASS: TestRegisterCallbackWithOrder (0.00s)
    === RUN TestRegisterCallbackWithComplexOrder
    --- PASS: TestRegisterCallbackWithComplexOrder (0.00s)
    === RUN TestReplaceCallback
    [info] replacing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:94
    --- PASS: TestReplaceCallback (0.00s)
    === RUN TestRemoveCallback
    [info] removing callback `create` from /Users/jay/go/src/github.com/jinzhu/gorm/callback_test.go:107
    --- PASS: TestRemoveCallback (0.00s)
    === RUN TestCloneSearch
    --- PASS: TestCloneSearch (0.00s)
    === RUN TestHasOneAndHasManyAssociation
    --- PASS: TestHasOneAndHasManyAssociation (0.01s)
    === RUN TestRelated
    --- PASS: TestRelated (0.00s)
    === RUN TestManyToMany
    --- PASS: TestManyToMany (0.07s)
    === RUN TestForeignKey
    --- PASS: TestForeignKey (0.00s)
    === RUN TestRunCallbacks
    --- PASS: TestRunCallbacks (0.01s)
    === RUN TestCallbacksWithErrors
    --- PASS: TestCallbacksWithErrors (0.01s)
    === RUN TestCreate
    --- PASS: TestCreate (0.00s)
    === RUN TestCreateWithNoGORMPrimayKey
    --- PASS: TestCreateWithNoGORMPrimayKey (0.00s)
    === RUN TestCreateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestCreateWithNoStdPrimaryKeyAndDefaultValues (0.00s)
    === RUN TestAnonymousScanner
    --- PASS: TestAnonymousScanner (0.00s)
    === RUN TestAnonymousField
    --- PASS: TestAnonymousField (0.00s)
    === RUN TestSelectWithCreate
    --- PASS: TestSelectWithCreate (0.00s)
    === RUN TestOmitWithCreate
    --- PASS: TestOmitWithCreate (0.00s)
    === RUN TestCustomizeColumn
    --- PASS: TestCustomizeColumn (0.00s)
    === RUN TestCustomColumnAndIgnoredFieldClash
    --- PASS: TestCustomColumnAndIgnoredFieldClash (0.00s)
    === RUN TestDelete
    --- PASS: TestDelete (0.00s)
    === RUN TestInlineDelete
    --- PASS: TestInlineDelete (0.00s)
    === RUN TestSoftDelete
    --- PASS: TestSoftDelete (0.00s)
    === RUN TestSaveAndQueryEmbeddedStruct
    --- PASS: TestSaveAndQueryEmbeddedStruct (0.00s)
    === RUN TestJoinTable
    --- PASS: TestJoinTable (0.01s)
    === RUN TestExceptionsWithInvalidSql
    --- PASS: TestExceptionsWithInvalidSql (0.00s)
    === RUN TestSetTable
    --- PASS: TestSetTable (0.02s)
    === RUN TestHasTable
    --- PASS: TestHasTable (0.00s)
    === RUN TestTableName
    --- PASS: TestTableName (0.00s)
    === RUN TestSqlNullValue
    --- PASS: TestSqlNullValue (0.00s)
    === RUN TestTransaction
    --- PASS: TestTransaction (0.00s)
    === RUN TestRow
    --- PASS: TestRow (0.00s)
    === RUN TestRows
    --- PASS: TestRows (0.00s)
    === RUN TestScan
    --- PASS: TestScan (0.00s)
    === RUN TestRaw
    --- PASS: TestRaw (0.01s)
    === RUN TestGroup
    --- PASS: TestGroup (0.00s)
    === RUN TestJoins
    --- PASS: TestJoins (0.00s)
    === RUN TestHaving
    --- PASS: TestHaving (0.00s)
    === RUN TestTimeWithZone
    --- PASS: TestTimeWithZone (0.00s)
    === RUN TestHstore
    --- SKIP: TestHstore (0.00s)
    	main_test.go:506:
    === RUN TestSetAndGet
    --- PASS: TestSetAndGet (0.00s)
    === RUN TestCompatibilityMode
    `testdb` is not officially supported, running under compatibility mode.
    --- PASS: TestCompatibilityMode (0.00s)
    === RUN TestOpenExistingDB
    `sqlite` is not officially supported, running under compatibility mode.
    --- PASS: TestOpenExistingDB (0.00s)
    === RUN TestIndexes
    --- PASS: TestIndexes (0.01s)
    === RUN TestAutoMigration
    --- PASS: TestAutoMigration (0.01s)
    === RUN TestPointerFields
    --- PASS: TestPointerFields (0.01s)
    === RUN TestPolymorphic
    --- PASS: TestPolymorphic (0.01s)
    === RUN TestPreload
    --- PASS: TestPreload (0.02s)
    === RUN TestFirstAndLast
    --- PASS: TestFirstAndLast (0.00s)
    === RUN TestFirstAndLastWithNoStdPrimaryKey
    --- PASS: TestFirstAndLastWithNoStdPrimaryKey (0.00s)
    === RUN TestUIntPrimaryKey
    --- PASS: TestUIntPrimaryKey (0.00s)
    === RUN TestFindAsSliceOfPointers
    --- PASS: TestFindAsSliceOfPointers (0.01s)
    === RUN TestSearchWithPlainSQL
    --- PASS: TestSearchWithPlainSQL (0.01s)
    === RUN TestSearchWithStruct
    --- PASS: TestSearchWithStruct (0.01s)
    === RUN TestSearchWithMap
    --- PASS: TestSearchWithMap (0.00s)
    === RUN TestSearchWithEmptyChain
    --- PASS: TestSearchWithEmptyChain (0.00s)
    === RUN TestSelect
    --- PASS: TestSelect (0.00s)
    === RUN TestOrderAndPluck
    --- PASS: TestOrderAndPluck (0.01s)
    === RUN TestLimit
    --- PASS: TestLimit (0.01s)
    === RUN TestOffset
    --- PASS: TestOffset (0.04s)
    === RUN TestOr
    --- PASS: TestOr (0.00s)
    === RUN TestCount
    --- PASS: TestCount (0.00s)
    === RUN TestNot
    --- PASS: TestNot (0.02s)
    === RUN TestFillSmallerStruct
    --- PASS: TestFillSmallerStruct (0.02s)
    === RUN TestFindOrInitialize
    --- PASS: TestFindOrInitialize (0.00s)
    === RUN TestFindOrCreate
    --- PASS: TestFindOrCreate (0.01s)
    === RUN TestSelectWithEscapedFieldName
    --- PASS: TestSelectWithEscapedFieldName (0.00s)
    === RUN TestSelectWithVariables
    --- PASS: TestSelectWithVariables (0.00s)
    === RUN TestSelectWithArrayInput
    --- PASS: TestSelectWithArrayInput (5.01s)
    === RUN TestScopes
    --- PASS: TestScopes (0.00s)
    === RUN TestScannableSlices
    --- PASS: TestScannableSlices (0.00s)
    === RUN TestUpdate
    --- PASS: TestUpdate (0.00s)
    === RUN TestUpdateWithNoStdPrimaryKeyAndDefaultValues
    --- PASS: TestUpdateWithNoStdPrimaryKeyAndDefaultValues (0.00s)
    === RUN TestUpdates
    --- PASS: TestUpdates (0.00s)
    === RUN TestUpdateColumn
    --- PASS: TestUpdateColumn (0.00s)
    === RUN TestSelectWithUpdate
    --- PASS: TestSelectWithUpdate (0.00s)
    === RUN TestSelectWithUpdateWithMap
    --- PASS: TestSelectWithUpdateWithMap (0.01s)
    === RUN TestOmitWithUpdate
    --- PASS: TestOmitWithUpdate (0.00s)
    === RUN TestOmitWithUpdateWithMap
    --- PASS: TestOmitWithUpdateWithMap (0.00s)
    === RUN TestSelectWithUpdateColumn
    --- PASS: TestSelectWithUpdateColumn (0.00s)
    === RUN TestOmitWithUpdateColumn
    --- PASS: TestOmitWithUpdateColumn (0.00s)
    PASS
    ok  	github.com/jinzhu/gorm	5.598s
