### PR TITLE
Skip saving associations during UpdateColumns(...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ db.Model(&user).Updates(User{Name: "hello", Age: 18})
 
 ### Update Without Callbacks
 
-By default, update will call BeforeUpdate, AfterUpdate callbacks, if you want to update w/o callbacks:
+By default, update will call BeforeUpdate, AfterUpdate callbacks, if you want to update w/o callbacks and w/o saving associations:
 
 ```go
 db.Model(&user).UpdateColumn("name", "hello")

--- a/callback_shared.go
+++ b/callback_shared.go
@@ -11,6 +11,9 @@ func CommitOrRollbackTransaction(scope *Scope) {
 }
 
 func SaveBeforeAssociations(scope *Scope) {
+	if !scope.shouldSaveAssociations() {
+		return
+	}
 	for _, field := range scope.Fields() {
 		if scope.changeableField(field) && !field.IsBlank && !field.IsIgnored {
 			if relationship := field.Relationship; relationship != nil && relationship.Kind == "belongs_to" {
@@ -25,6 +28,9 @@ func SaveBeforeAssociations(scope *Scope) {
 }
 
 func SaveAfterAssociations(scope *Scope) {
+	if !scope.shouldSaveAssociations() {
+		return
+	}
 	for _, field := range scope.Fields() {
 		if scope.changeableField(field) && !field.IsBlank && !field.IsIgnored {
 			if relationship := field.Relationship; relationship != nil &&

--- a/main.go
+++ b/main.go
@@ -266,6 +266,7 @@ func (s *DB) UpdateColumn(attrs ...interface{}) *DB {
 func (s *DB) UpdateColumns(values interface{}) *DB {
 	return s.clone().NewScope(s.Value).
 		Set("gorm:update_column", true).
+		Set("gorm:save_associations", false).
 		InstanceSet("gorm:update_interface", values).
 		callCallbacks(s.parent.callback.updates).db
 }

--- a/scope.go
+++ b/scope.go
@@ -398,3 +398,11 @@ func (scope *Scope) changeableField(field *Field) bool {
 
 	return !field.IsIgnored
 }
+
+func (scope *Scope) shouldSaveAssociations() bool {
+	saveAssociations, ok := scope.Get("gorm:save_associations")
+	if ok && !saveAssociations.(bool) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Yesterday I noticed that when invoking `UpdateColumns(...)` it would try to save all associated records.  I found this to be highly undesirable and it seemed like only an `UPDATE ...` statement should have been run.

This patch achieves the desired effect for at `UpdateColumns(...)`.

Relevant unit-test is included.

    === RUN TestUpdateColumnsSkipsAssociations
    --- PASS: TestUpdateColumnsSkipsAssociations (0.10s)
    PASS

All unit tests:

    ok  	github.com/jinzhu/gorm	2.576s
