### PR TITLE
look up the Field.Name in Scope.SetColumn

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -164,7 +164,7 @@ func (scope *Scope) SetColumn(column interface{}, value interface{}) error {
 			return field.Set(value)
 		}
 
-		dbName = ToDBName(name)
+		dbName := ToDBName(name)
 		if field, ok := scope.Fields()[dbName]; ok {
 			return field.Set(value)
 		}

--- a/scope.go
+++ b/scope.go
@@ -158,13 +158,18 @@ func (scope *Scope) HasColumn(column string) bool {
 func (scope *Scope) SetColumn(column interface{}, value interface{}) error {
 	if field, ok := column.(*Field); ok {
 		return field.Set(value)
-	} else if dbName, ok := column.(string); ok {
+	} else if name, ok := column.(string); ok {
+
+		if field, ok := scope.Fields()[name]; ok {
+			return field.Set(value)
+		}
+
+		dbName = ToDBName(name)
 		if field, ok := scope.Fields()[dbName]; ok {
 			return field.Set(value)
 		}
 
-		dbName = ToDBName(dbName)
-		if field, ok := scope.Fields()[dbName]; ok {
+		if field, ok := scope.FieldByName(name); ok {
 			return field.Set(value)
 		}
 	}


### PR DESCRIPTION
in `callback_create.go`,  there is a callback to set CreatedAt and UdpatedAt
```
func UpdateTimeStampWhenCreate(scope *Scope) {
	if !scope.HasError() {
		now := NowFunc()
		scope.SetColumn("CreatedAt", now)
		scope.SetColumn("UpdatedAt", now)
	}
}
```

but if specified a different database column name, like this : 
```
	CreatedAt    time.Time  `gorm:"column:page_created"`
	UpdatedAt    time.Time  `gorm:"column:page_updated"`
```

the SetColumn wont set the CreateAt field correctly, this PullRequest will fix this.