### PR TITLE
Quote the primary column name when doing queries

### DIFF
--- a/callback_query.go
+++ b/callback_query.go
@@ -18,7 +18,7 @@ func Query(scope *Scope) {
 
 	if orderBy, ok := scope.Get("gorm:order_by_primary_key"); ok {
 		if primaryKey := scope.PrimaryKey(); primaryKey != "" {
-			scope.Search.Order(fmt.Sprintf("%v.%v %v", scope.QuotedTableName(), primaryKey, orderBy))
+			scope.Search.Order(fmt.Sprintf("%v.%v %v", scope.QuotedTableName(), scope.Quote(primaryKey), orderBy))
 		}
 	}
 


### PR DESCRIPTION
Postgresql requires certain column names to be quoted.
When unquoted, all upper-case characters will be converted to lower-case,
and column names like 'typeID' will result in a query on 'typeid', which will fail the query.