### PR TITLE
Fix including ignored field in Where condition

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -38,7 +38,7 @@ func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str stri
 	case interface{}:
 		var sqls []string
 		for _, field := range scope.New(value).Fields() {
-			if !field.IsBlank {
+			if !field.IsIgnored && !field.IsBlank {
 				sqls = append(sqls, fmt.Sprintf("(%v = %v)", scope.Quote(field.DBName), scope.AddToVars(field.Field.Interface())))
 			}
 		}


### PR DESCRIPTION
Ignored (non-blank) fields still show up in the SQL, with an empty column name. This causes an error in Postgres, but strangely not in SQLite.

Consider:
```go
type User struct {
	Id      int64
	Name    string
	Ignored string `sql:"-"`
}

u := User{
	Name:    "bob",
	Ignored: "some_value",
}

var r User
// SQL: SELECT  * FROM "users"  WHERE ("name" = 'bob') AND ("" = 'some_value') ORDER BY "users"."id" ASC LIMIT 1
if err := db.First(&r, &u).Error; err != nil {
	t.Fatal(err) // ERROR: zero-length delimited identifier at or near """"
}
```