### PR TITLE
Added support of embedded interface fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,7 +1172,7 @@ db.Where("email = ?", "x@example.org").Attrs(User{RegisteredIp: "111.111.111.111
 //// INSERT INTO "users" (email,registered_ip) VALUES ("x@example.org", "111.111.111.111")  // if record not found
 ```
 
-## Tables with embedded iterface fields
+## Embedded interface fields
 
 ```go
 type Delta struct {
@@ -1207,7 +1207,12 @@ found := Delta {
 	Became: &Login{},
 }
 db.Where(&Delta{Was: &Login{Login: "Login1"}, Became: &Login{}}).First(&found);
-//// SELECT  * FROM "delta__Login__Login"  WHERE ("was__login" = 'Login1') ORDER BY "delta__Login__Login"."id" ASC LIMIT 1
+//// SELECT * FROM "delta__Login__Login"  WHERE ("was__login" = 'Login1') ORDER BY "delta__Login__Login"."id" ASC LIMIT 1
+
+deltas := []Delta{{Was: &Login{}, Became: &Login{}}};
+db.Find(&deltas)
+//// SELECT * FROM "deltas__Login__Login"
+deltas = append(deltas[:0], deltas[1:]...)
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -1177,8 +1177,8 @@ db.Where("email = ?", "x@example.org").Attrs(User{RegisteredIp: "111.111.111.111
 ```go
 type Delta struct {
 	Id       int;
-	Was      interface{} `gorm:"embedded:prefixed"`;
-	Became   interface{} `gorm:"embedded:prefixed"`;
+	Was      interface{} `gorm:"embedded:prefixed;drop_primary_keys;drop_unique_index"`;
+	Became   interface{} `gorm:"embedded:prefixed;drop_primary_keys;drop_unique_index"`;
 }
 
 type Login struct {

--- a/README.md
+++ b/README.md
@@ -1172,6 +1172,44 @@ db.Where("email = ?", "x@example.org").Attrs(User{RegisteredIp: "111.111.111.111
 //// INSERT INTO "users" (email,registered_ip) VALUES ("x@example.org", "111.111.111.111")  // if record not found
 ```
 
+## Tables with embedded iterface fields
+
+```go
+type Delta struct {
+	Id       int;
+	Was      interface{} `gorm:"embedded"`;
+	Became   interface{} `gorm:"embedded"`;
+}
+
+type Login struct {
+	Login    string;
+	Comment  string;
+}
+
+login_old := Login{Login: "Login1"};
+login_new := Login{Login: "Login2", Comment: "2015-05-18"};
+
+delta := Delta {
+	Was:    &login_old,
+	Became: &login_new,
+}
+
+db.SingularTable(true);
+
+db.CreateTable(&delta);
+//// CREATE TABLE "delta__Login__Login" ("id" integer,"was__login" varchar(255),"was__comment" varchar(255),"became__login" varchar(255),"became__comment" varchar(255) , PRIMARY KEY (id))
+
+db.Save(&delta);
+//// INSERT INTO "delta__Login__Login" ("was__login","was__comment","became__login","became__comment") VALUES ('Login1','','Login2','2015-05-18')
+
+found := Delta {
+	Was:    &Login{},
+	Became: &Login{},
+}
+db.Where(&Delta{Was: &Login{Login: "Login1"}, Became: &Login{}}).First(&found);
+//// SELECT  * FROM "delta__Login__Login"  WHERE ("was__login" = 'Login1') ORDER BY "delta__Login__Login"."id" ASC LIMIT 1
+```
+
 ## TODO
 * db.Select("Languages", "Name").Update(&user)
   db.Omit("Languages").Update(&user)

--- a/README.md
+++ b/README.md
@@ -1177,8 +1177,8 @@ db.Where("email = ?", "x@example.org").Attrs(User{RegisteredIp: "111.111.111.111
 ```go
 type Delta struct {
 	Id       int;
-	Was      interface{} `gorm:"embedded"`;
-	Became   interface{} `gorm:"embedded"`;
+	Was      interface{} `gorm:"embedded:prefixed"`;
+	Became   interface{} `gorm:"embedded:prefixed"`;
 }
 
 type Login struct {

--- a/field.go
+++ b/field.go
@@ -76,6 +76,9 @@ func (scope *Scope) Fields() map[string]*Field {
 func getField(indirectValue reflect.Value, structField *StructField) *Field {
 	field := &Field{StructField: structField}
 	for _, name := range structField.Names {
+		if (reflect.Indirect(indirectValue).Kind() == reflect.Interface) {
+			indirectValue = indirectValue.Elem()
+		}
 		indirectValue = reflect.Indirect(indirectValue).FieldByName(name)
 	}
 	field.Field = indirectValue

--- a/field.go
+++ b/field.go
@@ -76,8 +76,12 @@ func (scope *Scope) Fields() map[string]*Field {
 func getField(indirectValue reflect.Value, structField *StructField) *Field {
 	field := &Field{StructField: structField}
 	for _, name := range structField.Names {
-		if (reflect.Indirect(indirectValue).Kind() == reflect.Interface) {
-			indirectValue = indirectValue.Elem()
+		for ;reflect.Indirect(indirectValue).Kind() == reflect.Interface; {
+			if (indirectValue.Elem().IsValid()) {
+				indirectValue = indirectValue.Elem()
+			} else {
+				indirectValue.Set(reflect.New(structField.Value.Type()))
+			}
 		}
 		indirectValue = reflect.Indirect(indirectValue).FieldByName(name)
 	}

--- a/main.go
+++ b/main.go
@@ -126,7 +126,8 @@ func (s *DB) LogMode(enable bool) *DB {
 }
 
 func (s *DB) SingularTable(enable bool) {
-	modelStructs = map[reflect.Type]*ModelStruct{}
+	modelStructs_byScopeType = map[reflect.Type]*ModelStruct{}
+	modelStructs_byTableName = map[string      ]*ModelStruct{}
 	s.parent.singularTable = enable
 }
 

--- a/model_struct.go
+++ b/model_struct.go
@@ -165,6 +165,12 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 			} else {
 				value = reflect.Indirect(reflect.ValueOf(scope.Value))
 			}
+			if (value.Kind() == reflect.Slice) {
+				if (value.Len() == 0) {
+					value = reflect.MakeSlice(value.Type(), 1, 1);
+				}
+				value = value.Index(0);
+			}
 			field := &StructField{
 				Struct: fieldStruct,
 				Value:  value,

--- a/model_struct.go
+++ b/model_struct.go
@@ -156,7 +156,11 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 		if fieldStruct := scopeType.Field(i); ast.IsExported(fieldStruct.Name) {
 			var value reflect.Value
 			if (fieldStruct.Type.Kind() == reflect.Interface) {
-				value = reflect.ValueOf(reflect.ValueOf(scope.Value).Elem().Field(i).Interface())
+				value = reflect.ValueOf(scope.Value).Elem()
+				if (value.Kind() == reflect.Slice) {
+					value = value.Index(0)
+				}
+				value = reflect.ValueOf(value.Field(i).Interface())
 				cachable_byScopeType = false
 			} else {
 				value = reflect.Indirect(reflect.ValueOf(scope.Value))

--- a/model_struct.go
+++ b/model_struct.go
@@ -299,10 +299,12 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 							field.IsNormal = true
 						}
 					case reflect.Struct:
-						if _, ok := gormSettings["EMBEDDED"]; ok || fieldStruct.Anonymous {
+						if embType, ok := gormSettings["EMBEDDED"]; ok || fieldStruct.Anonymous {
 							for _, toField := range toScope.GetStructFields() {
 								toField = toField.clone()
-								toField.DBName = field.DBName+"__"+toField.DBName
+								if (embType == "prefixed") {
+									toField.DBName = field.DBName+"__"+toField.DBName
+								}
 								toField.Names  = append([]string{fieldStruct.Name}, toField.Names...)
 								modelStruct.StructFields = append(modelStruct.StructFields, toField)
 								if toField.IsPrimaryKey {

--- a/scope_private.go
+++ b/scope_private.go
@@ -572,7 +572,7 @@ func (scope *Scope) autoIndex() *Scope {
 			indexes[name] = append(indexes[name], field.DBName)
 		}
 
-		if field.IgnoreUniqueIndex {
+		if !field.IgnoreUniqueIndex {
 			if name, ok := sqlSettings["UNIQUE_INDEX"]; ok {
 				if name == "UNIQUE_INDEX" {
 					name = fmt.Sprintf("uix_%v_%v", scope.TableName(), field.DBName)

--- a/scope_private.go
+++ b/scope_private.go
@@ -474,7 +474,7 @@ func (scope *Scope) createTable() *Scope {
 			tags = append(tags, scope.Quote(field.DBName)+" "+sqlTag)
 		}
 
-		if field.IsPrimaryKey {
+		if field.IsPrimaryKey && !field.IgnorePrimaryKey {
 			primaryKeys = append(primaryKeys, field.DBName)
 		}
 		scope.createJoinTable(field)
@@ -572,11 +572,13 @@ func (scope *Scope) autoIndex() *Scope {
 			indexes[name] = append(indexes[name], field.DBName)
 		}
 
-		if name, ok := sqlSettings["UNIQUE_INDEX"]; ok {
-			if name == "UNIQUE_INDEX" {
-				name = fmt.Sprintf("uix_%v_%v", scope.TableName(), field.DBName)
+		if field.IgnoreUniqueIndex {
+			if name, ok := sqlSettings["UNIQUE_INDEX"]; ok {
+				if name == "UNIQUE_INDEX" {
+					name = fmt.Sprintf("uix_%v_%v", scope.TableName(), field.DBName)
+				}
+				uniqueIndexes[name] = append(uniqueIndexes[name], field.DBName)
 			}
-			uniqueIndexes[name] = append(uniqueIndexes[name], field.DBName)
 		}
 	}
 


### PR DESCRIPTION
I understand if this will never be merged. However I need this functionality and I'm hoping for the merging.

I have a lot of structures and one structure "Delta" that is used to save information about data changes. Logically Delta is just a template, but I didn't find any C++-like templates in golang, so I was have to use "interfaces". This patch just adds support of such use case into the GORM.

```go
type Delta struct {
        Id       int;
        Was      interface{} `gorm:"embedded:prefixed"`;
        Became   interface{} `gorm:"embedded:prefixed"`;
}

type Login struct {
        Login    string;
        Comment  string;
}

login_old := Login{Login: "Login1"};
login_new := Login{Login: "Login2", Comment: "2015-05-18"};

delta := Delta {
        Was:    &login_old,
        Became: &login_new,
}

db.SingularTable(true);

db.CreateTable(&delta);
//// CREATE TABLE "delta__Login__Login" ("id" integer,"was__login" varchar(255),"was__comment" varchar(255),"became__login" varchar(255),"became__comment" varchar(255) , PRIMARY KEY (id))

db.Save(&delta);
//// INSERT INTO "delta__Login__Login" ("was__login","was__comment","became__login","became__comment") VALUES ('Login1','','Login2','2015-05-18')

found := Delta {
        Was:    &Login{},
        Became: &Login{},
}
db.Where(&Delta{Was: &Login{Login: "Login1"}, Became: &Login{}}).First(&found);
//// SELECT * FROM "delta__Login__Login"  WHERE ("was__login" = 'Login1') ORDER BY "delta__Login__Login"."id" ASC LIMIT 1

deltas := []Delta{{Was: &Login{}, Became: &Login{}}};
db.Find(&deltas)
//// SELECT * FROM "deltas__Login__Login"
deltas = append(deltas[:0], deltas[1:]...)
```