### PR TITLE
Fixed the "Query callbacks" URL.

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -61,7 +61,7 @@ Gorm is powered by callbacks, so you could refer below links to learn how to wri
 
 [Update callbacks](https://github.com/jinzhu/gorm/blob/master/callback_update.go)
 
-[Query callbacks](https://github.com/jinzhu/gorm/blob/master/callback_create.go)
+[Query callbacks](https://github.com/jinzhu/gorm/blob/master/callback_query.go)
 
 [Delete callbacks](https://github.com/jinzhu/gorm/blob/master/callback_delete.go)
 


### PR DESCRIPTION
Changed it to point to `callback_query.go` instead of `callback_create.go`.