### PR TITLE
insert_id only support auto_increment field

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -40,6 +40,7 @@ type StructField struct {
 	Tag             reflect.StructTag
 	Struct          reflect.StructField
 	IsForeignKey    bool
+	IsAutoIncrement bool
 	Relationship    *Relationship
 }
 
@@ -146,6 +147,10 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 
 				if _, ok := sqlSettings["DEFAULT"]; ok {
 					field.HasDefaultValue = true
+				}
+
+				if _, ok := sqlSettings["AUTO_INCREMENT"]; ok {
+					field.IsAutoIncrement = true
 				}
 
 				if value, ok := gormSettings["COLUMN"]; ok {

--- a/scope.go
+++ b/scope.go
@@ -112,12 +112,11 @@ func (scope *Scope) HasError() bool {
 
 func (scope *Scope) PrimaryField() *Field {
 	if primaryFields := scope.GetModelStruct().PrimaryFields; len(primaryFields) > 0 {
-		if len(primaryFields) > 1 {
-			if field, ok := scope.Fields()["id"]; ok {
-				return field
+		for i := 0; i < len(primaryFields); i++ {
+			if primaryFields[i].IsAutoIncrement {
+				return scope.Fields()[primaryFields[i].DBName]
 			}
 		}
-		return scope.Fields()[primaryFields[0].DBName]
 	}
 	return nil
 }


### PR DESCRIPTION
When create a record, insert_id which supported can only assign to an auto_increment field