### PR TITLE
Update README for revertable transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,9 @@ All individual save and delete operations are run in a transaction by default.
 // begin
 tx := db.Begin()
 
+// do revertable work in a transaction (use 'tx' in place of 'db')
+tx.Exec
+
 // rollback
 tx.Rollback()
 


### PR DESCRIPTION
My tests are showing that transactions are not being rolled back if done through the original *db* object.
The update to the README clarifies that revertible operations must be done through the returned *tx* object.