### PR TITLE
Add `*DB' param to JoinTableHandlerInterface.`Setup' interface

### DIFF
--- a/join_table_handler.go
+++ b/join_table_handler.go
@@ -8,7 +8,7 @@ import (
 )
 
 type JoinTableHandlerInterface interface {
-	Setup(relationship *Relationship, tableName string, source reflect.Type, destination reflect.Type)
+	Setup(db *DB, relationship *Relationship, tableName string, source reflect.Type, destination reflect.Type)
 	Table(db *DB) string
 	Add(handler JoinTableHandlerInterface, db *DB, source interface{}, destination interface{}) error
 	Delete(handler JoinTableHandlerInterface, db *DB, sources ...interface{}) error
@@ -41,7 +41,7 @@ func (s *JoinTableHandler) DestinationForeignKeys() []JoinTableForeignKey {
 	return s.Destination.ForeignKeys
 }
 
-func (s *JoinTableHandler) Setup(relationship *Relationship, tableName string, source reflect.Type, destination reflect.Type) {
+func (s *JoinTableHandler) Setup(db *DB, relationship *Relationship, tableName string, source reflect.Type, destination reflect.Type) {
 	s.TableName = tableName
 
 	s.Source = JoinTableSource{ModelType: source}
@@ -68,6 +68,7 @@ func (s *JoinTableHandler) Setup(relationship *Relationship, tableName string, s
 
 	s.Destination = JoinTableSource{ModelType: destination}
 	destinationScope := &Scope{Value: reflect.New(destination).Interface()}
+	destinationScope.db = db
 	destinationPrimaryFields := destinationScope.GetModelStruct().PrimaryFields
 	for _, primaryField := range destinationPrimaryFields {
 		var dbName string

--- a/main.go
+++ b/main.go
@@ -485,7 +485,7 @@ func (s *DB) SetJoinTableHandler(source interface{}, column string, handler Join
 			if many2many := parseTagSetting(field.Tag.Get("gorm"))["MANY2MANY"]; many2many != "" {
 				source := (&Scope{Value: source}).GetModelStruct().ModelType
 				destination := (&Scope{Value: reflect.New(field.Struct.Type).Interface()}).GetModelStruct().ModelType
-				handler.Setup(field.Relationship, many2many, source, destination)
+				handler.Setup(s, field.Relationship, many2many, source, destination)
 				field.Relationship.JoinTableHandler = handler
 				if table := handler.Table(s); scope.Dialect().HasTable(scope, table) {
 					s.Table(table).AutoMigrate(handler)

--- a/model_struct.go
+++ b/model_struct.go
@@ -229,7 +229,7 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 								relationship.AssociationForeignDBName = ToDBName(associationForeignKey)
 
 								joinTableHandler := JoinTableHandler{}
-								joinTableHandler.Setup(relationship, many2many, scopeType, elemType)
+								joinTableHandler.Setup(scope.db, relationship, many2many, scopeType, elemType)
 								relationship.JoinTableHandler = &joinTableHandler
 								field.Relationship = relationship
 							} else {


### PR DESCRIPTION
Add `*DB' param to JoinTableHandlerInterface.`Setup' interface to preserve DB settings in intermediate setup scope.

Fixes previously non-functioning/broken use-case:

- Using the `gorm:many2many' relations tag with `db.SingularTable(true)' should always reference singular table names.