### PR TITLE
overwrite initiliazed slices as empty slices

### DIFF
--- a/callback_query.go
+++ b/callback_query.go
@@ -30,7 +30,9 @@ func Query(scope *Scope) {
 	if kind := dest.Kind(); kind == reflect.Slice {
 		isSlice = true
 		destType = dest.Type().Elem()
-		dest.Set(reflect.Indirect(reflect.New(reflect.SliceOf(destType))))
+		if !dest.IsNil() {
+			dest.Set(reflect.MakeSlice(dest.Type(), 0, 0))
+		}
 
 		if destType.Kind() == reflect.Ptr {
 			isPtr = true


### PR DESCRIPTION
2d802c3 overwrites non nil slices as not initialized slices and this causes my json marshalled slices to be "null" instead of "[]". We can overwrite non nil slices as empty slices to avoid this unexpected behavior.