### PR TITLE
Table suffix to create tables with InnoDB engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ import (
 db, err := gorm.Open("postgres", "user=gorm dbname=gorm sslmode=disable")
 // db, err := gorm.Open("foundation", "dbname=gorm") // FoundationDB.
 // db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
-// db, err := gorm.OpenWithTableSuffix("mysql", "ENGINE=InnoDB", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
 // db, err := gorm.Open("sqlite3", "/tmp/gorm.db")
 
 // You can also use an existing database connection handle
@@ -137,12 +136,14 @@ db.SingularTable(true)
 ```go
 // Create table
 db.CreateTable(&User{})
+db.Set("gorm:table_options", "ENGINE=InnoDB").CreateTable(&User{})
 
 // Drop table
 db.DropTable(&User{})
 
 // Automating Migration
 db.AutoMigrate(&User{})
+db.Set("gorm:table_options", "ENGINE=InnoDB").AutoMigrate(&User{})
 db.AutoMigrate(&User{}, &Product{}, &Order{})
 // Feel free to change your struct, AutoMigrate will keep your database up-to-date.
 // AutoMigrate will ONLY add *new columns* and *new indexes*,

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ import (
 db, err := gorm.Open("postgres", "user=gorm dbname=gorm sslmode=disable")
 // db, err := gorm.Open("foundation", "dbname=gorm") // FoundationDB.
 // db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
+// db, err := gorm.OpenWithTableSuffix("mysql", "ENGINE=InnoDB", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
 // db, err := gorm.Open("sqlite3", "/tmp/gorm.db")
 
 // You can also use an existing database connection handle

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ type DB struct {
 }
 
 func Open(dialect string, args ...interface{}) (DB, error) {
-    return OpenWithTableSuffix(dialect, "", args)
+    return OpenWithTableSuffix(dialect, "", args...)
 }
 
 func OpenWithTableSuffix(dialect, tableSuffix string, args ...interface{}) (DB, error) {

--- a/main.go
+++ b/main.go
@@ -32,11 +32,16 @@ type DB struct {
 	dialect           Dialect
 	singularTable     bool
 	source            string
+    tableSuffix       string
 	values            map[string]interface{}
 	joinTableHandlers map[string]JoinTableHandler
 }
 
 func Open(dialect string, args ...interface{}) (DB, error) {
+    return OpenWithTableSuffix(dialect, "", args)
+}
+
+func OpenWithTableSuffix(dialect, tableSuffix string, args ...interface{}) (DB, error) {
 	var db DB
 	var err error
 
@@ -69,6 +74,7 @@ func Open(dialect string, args ...interface{}) (DB, error) {
 			logger:   defaultLogger,
 			callback: DefaultCallback,
 			source:   source,
+            tableSuffix:tableSuffix,
 			values:   map[string]interface{}{},
 			db:       dbSql,
 		}
@@ -370,7 +376,7 @@ func (s *DB) RecordNotFound() bool {
 
 // Migrations
 func (s *DB) CreateTable(value interface{}) *DB {
-	return s.clone().NewScope(value).createTable().db
+	return s.clone().NewScope(value).Set("gorm:table_suffix", s.tableSuffix).createTable().db
 }
 
 func (s *DB) DropTable(value interface{}) *DB {
@@ -390,7 +396,7 @@ func (s *DB) HasTable(value interface{}) bool {
 func (s *DB) AutoMigrate(values ...interface{}) *DB {
 	db := s.clone()
 	for _, value := range values {
-		db = db.NewScope(value).NeedPtr().autoMigrate().db
+		db = db.NewScope(value).NeedPtr().Set("gorm:table_suffix", s.tableSuffix).autoMigrate().db
 	}
 	return db
 }

--- a/main.go
+++ b/main.go
@@ -32,16 +32,11 @@ type DB struct {
 	dialect           Dialect
 	singularTable     bool
 	source            string
-    tableSuffix       string
 	values            map[string]interface{}
 	joinTableHandlers map[string]JoinTableHandler
 }
 
 func Open(dialect string, args ...interface{}) (DB, error) {
-    return OpenWithTableSuffix(dialect, "", args...)
-}
-
-func OpenWithTableSuffix(dialect, tableSuffix string, args ...interface{}) (DB, error) {
 	var db DB
 	var err error
 
@@ -74,7 +69,6 @@ func OpenWithTableSuffix(dialect, tableSuffix string, args ...interface{}) (DB, 
 			logger:   defaultLogger,
 			callback: DefaultCallback,
 			source:   source,
-            tableSuffix:tableSuffix,
 			values:   map[string]interface{}{},
 			db:       dbSql,
 		}
@@ -376,7 +370,7 @@ func (s *DB) RecordNotFound() bool {
 
 // Migrations
 func (s *DB) CreateTable(value interface{}) *DB {
-	return s.clone().NewScope(value).Set("gorm:table_suffix", s.tableSuffix).createTable().db
+	return s.clone().NewScope(value).createTable().db
 }
 
 func (s *DB) DropTable(value interface{}) *DB {
@@ -396,7 +390,7 @@ func (s *DB) HasTable(value interface{}) bool {
 func (s *DB) AutoMigrate(values ...interface{}) *DB {
 	db := s.clone()
 	for _, value := range values {
-		db = db.NewScope(value).NeedPtr().Set("gorm:table_suffix", s.tableSuffix).autoMigrate().db
+		db = db.NewScope(value).NeedPtr().autoMigrate().db
 	}
 	return db
 }

--- a/scope_private.go
+++ b/scope_private.go
@@ -442,6 +442,17 @@ func (scope *Scope) related(value interface{}, foreignKeys ...string) *Scope {
 	return scope
 }
 
+/**
+    Return the table suffix string or an empty string if the table suffix does not exist
+*/
+func (scope *Scope) getTableSuffix() string{
+    tableSuffix, ok := scope.Get("gorm:table_suffix")
+    if !ok {
+        return ""
+    }
+    return tableSuffix.(string)
+}
+
 func (scope *Scope) createJoinTable(field *StructField) {
 	if relationship := field.Relationship; relationship != nil && relationship.JoinTableHandler != nil {
 		joinTableHandler := relationship.JoinTableHandler
@@ -458,8 +469,7 @@ func (scope *Scope) createJoinTable(field *StructField) {
 					sqlTypes = append(sqlTypes, scope.Quote(dbName)+" "+primaryKeySqlType)
 				}
 			}
-
-			scope.Err(scope.NewDB().Exec(fmt.Sprintf("CREATE TABLE %v (%v)", scope.Quote(joinTable), strings.Join(sqlTypes, ","))).Error)
+			scope.Err(scope.NewDB().Exec(fmt.Sprintf("CREATE TABLE %v (%v) %s", scope.Quote(joinTable), strings.Join(sqlTypes, ","), scope.getTableSuffix())).Error)
 		}
 		scope.NewDB().Table(joinTable).AutoMigrate(joinTableHandler)
 	}
@@ -484,7 +494,7 @@ func (scope *Scope) createTable() *Scope {
 	if len(primaryKeys) > 0 {
 		primaryKeyStr = fmt.Sprintf(", PRIMARY KEY (%v)", strings.Join(primaryKeys, ","))
 	}
-	scope.Raw(fmt.Sprintf("CREATE TABLE %v (%v %v)", scope.QuotedTableName(), strings.Join(tags, ","), primaryKeyStr)).Exec()
+	scope.Raw(fmt.Sprintf("CREATE TABLE %v (%v %v) %s", scope.QuotedTableName(), strings.Join(tags, ","), primaryKeyStr, scope.getTableSuffix())).Exec()
 	return scope
 }
 

--- a/scope_private.go
+++ b/scope_private.go
@@ -443,14 +443,14 @@ func (scope *Scope) related(value interface{}, foreignKeys ...string) *Scope {
 }
 
 /**
-    Return the table suffix string or an empty string if the table suffix does not exist
+    Return the table options string or an empty string if the table options does not exist
 */
-func (scope *Scope) getTableSuffix() string{
-    tableSuffix, ok := scope.Get("gorm:table_suffix")
+func (scope *Scope) getTableOptions() string{
+    tableOptions, ok := scope.Get("gorm:table_options")
     if !ok {
         return ""
     }
-    return tableSuffix.(string)
+    return tableOptions.(string)
 }
 
 func (scope *Scope) createJoinTable(field *StructField) {
@@ -469,7 +469,7 @@ func (scope *Scope) createJoinTable(field *StructField) {
 					sqlTypes = append(sqlTypes, scope.Quote(dbName)+" "+primaryKeySqlType)
 				}
 			}
-			scope.Err(scope.NewDB().Exec(fmt.Sprintf("CREATE TABLE %v (%v) %s", scope.Quote(joinTable), strings.Join(sqlTypes, ","), scope.getTableSuffix())).Error)
+			scope.Err(scope.NewDB().Exec(fmt.Sprintf("CREATE TABLE %v (%v) %s", scope.Quote(joinTable), strings.Join(sqlTypes, ","), scope.getTableOptions())).Error)
 		}
 		scope.NewDB().Table(joinTable).AutoMigrate(joinTableHandler)
 	}
@@ -494,7 +494,7 @@ func (scope *Scope) createTable() *Scope {
 	if len(primaryKeys) > 0 {
 		primaryKeyStr = fmt.Sprintf(", PRIMARY KEY (%v)", strings.Join(primaryKeys, ","))
 	}
-	scope.Raw(fmt.Sprintf("CREATE TABLE %v (%v %v) %s", scope.QuotedTableName(), strings.Join(tags, ","), primaryKeyStr, scope.getTableSuffix())).Exec()
+	scope.Raw(fmt.Sprintf("CREATE TABLE %v (%v %v) %s", scope.QuotedTableName(), strings.Join(tags, ","), primaryKeyStr, scope.getTableOptions())).Exec()
 	return scope
 }
 


### PR DESCRIPTION
Hi all,

I've forked jinzhu/gorm more than a year ago, and did modify the code at that time to provide another mysql engine. For instance, the goal was to create tables with InnoDB engine without changing the default storage engine. It's time to share the code if some of you find some interest.

Code is pretty simple, but I did create a new function to distinguish the regular Open and the version with table options, called "OpenWithTableSuffix". Looking at latest syntax, https://dev.mysql.com/doc/refman/5.7/en/create-table.html, it exists several table options. Engine is one of the many possibilities. 

Best regards,
Gabriel