### PR TITLE
Fixed detecting pointers as a Scanner.

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -165,6 +165,10 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 					field.IsScanner, field.IsNormal = true, true
 				}
 
+				if _, isScanner := reflect.New(indirectType).Interface().(sql.Scanner); isScanner {
+					field.IsScanner, field.IsNormal = true, true
+				}
+
 				if _, isTime := reflect.New(indirectType).Interface().(*time.Time); isTime {
 					field.IsNormal = true
 				}


### PR DESCRIPTION
Hi!

I have code like this:

```go
type File struct {                                     
  ID        int                                                                          
  Info *FileInfo `sql:"type:jsonb"`        
}                                                      

type FileInfo struct {                                    
  // ... some stuff           
}  

func (f FileInfo) Value() (driver.Value, error) {                 
  valueString, err := json.Marshal(f)                             
  return string(valueString), err                                 
}                                                                 
                                                                  
func (f *FileInfo) Scan(value interface{}) error {                
  if err := json.Unmarshal(value.([]byte), &f); err != nil {      
    return err                                                    
  }                                                               
  return nil                                                      
}                                                                 
```

And it works pretty cool. Except auto migrations. It refuse to create a column for `FileInfo` filed.
This PR fixes it. 

Am I doing something wrong maybe?