### PR TITLE
Change logger to use an interface.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -14,8 +14,12 @@ type logger interface {
 	Print(v ...interface{})
 }
 
+type LogWriter interface {
+	Println(v ...interface{})
+}
+
 type Logger struct {
-	*log.Logger
+	LogWriter
 }
 
 var defaultLogger = Logger{log.New(os.Stdout, "\r\n", 0)}


### PR DESCRIPTION
This allows reuse of the nice formatting done by gorm while still sending the output to a custom logger.

For my use case it allowed easy integration with the glog library with a simple wrapper:

    type LogWrapper struct{}

    func (l *LogWrapper) Println(v ...interface{}) {
        glog.Info(v)
    }

and then something like:

`d.SetLogger(gorm.Logger{&LogWrapper{}})`