### PR TITLE
Added support to schema name in returning clause

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/lib/pq/hstore"
@@ -60,7 +61,12 @@ func (postgres) SqlTag(value reflect.Value, size int, autoIncrease bool) string 
 }
 
 func (s postgres) ReturningStr(tableName, key string) string {
-	return fmt.Sprintf("RETURNING %v.%v", s.Quote(tableName), key)
+	fullName := strings.Split(tableName,".")
+	if len(fullName) == 1 {
+		return fmt.Sprintf("RETURNING %v.%v", s.Quote(tableName), key)
+	} else {
+		return fmt.Sprintf("RETURNING %v.%v.%v", s.Quote(fullName[0]), s.Quote(fullName[1]), key)
+	}
 }
 
 func (s postgres) HasTable(scope *Scope, tableName string) bool {


### PR DESCRIPTION
The ReturningStr func was quoting schema and table name together:
```
INSERT INTO "xyz"."person" ... RETURNING "xyz.person"."idperson"
```
Causing the following error:
```
pq: missing FROM-clause entry for table \"xyz.person\"
```
I added support to schema name:
```
INSERT INTO "xyz"."person" .... RETURNING "xyz"."person"."idperson"
```