### PR TITLE
do not execute buildSelectQuery twice

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -217,7 +217,7 @@ func (scope *Scope) selectSql() string {
 	}
 	sql := scope.buildSelectQuery(scope.Search.selects)
 	scope.Search.countingQuery = (len(scope.Search.group) == 0) && hasCountRegexp.MatchString(sql)
-	return scope.buildSelectQuery(scope.Search.selects)
+	return sql
 }
 
 func (scope *Scope) orderSql() string {


### PR DESCRIPTION
if buildSelectQuery() is executed twice, then we get more values in SqlVars than expected