### PR TITLE
Fix where clause for string primary key when query value is numeric and starts with zero

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -64,6 +64,22 @@ func TestUIntPrimaryKey(t *testing.T) {
 	}
 }
 
+func TestStringPrimaryKeyForNumericValueStartingWithZero(t *testing.T) {
+	type AddressByZipCode struct {
+		ZipCode   string `gorm:"primary_key"`
+		Address   string
+	}
+
+	DB.AutoMigrate(&AddressByZipCode{})
+	DB.Create(&AddressByZipCode{ZipCode: "00501", Address: "Holtsville"})
+
+	var address AddressByZipCode
+	DB.First(&address, "00501")
+	if address.ZipCode != "00501" {
+		t.Errorf("Fetch a record from with a string primary key for a numeric value starting with zero should work, but failed")
+	}
+}
+
 func TestFindAsSliceOfPointers(t *testing.T) {
 	DB.Save(&User{Name: "user"})
 

--- a/scope_private.go
+++ b/scope_private.go
@@ -19,8 +19,7 @@ func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str stri
 	case string:
 		// if string is number
 		if regexp.MustCompile("^\\s*\\d+\\s*$").MatchString(value) {
-			id, _ := strconv.Atoi(value)
-			return scope.primaryCondition(scope.AddToVars(id))
+			return scope.primaryCondition(scope.AddToVars(value))
 		} else if value != "" {
 			str = fmt.Sprintf("(%v)", value)
 		}


### PR DESCRIPTION
Bug: Where condition when primary key is String and the query value start with zeros. For example: 
```go
type AddressByZipCode struct {
  ZipCode    string    `gorm:"primary_key:yes"`
  Address    string
}
```
When I search for a Address with `ZipCode = "00501"`:
```go
DB.First(&address, "00501")
```
The built SQL query with WHERE condition is:

```sql
  SELECT  * FROM "address_by_zip_codes"  WHERE ("zip_code" = '501') ORDER BY "address_by_zip_codes"."zip_code" ASC LIMIT 1
```
But the correct query is:
  ```sql
  SELECT  * FROM "address_by_zip_codes"  WHERE ("zip_code" = '00501') ORDER BY "address_by_zip_codes"."zip_code" ASC LIMIT 1
```