### PR TITLE
Fixed Typo in Default values Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1225,7 +1225,7 @@ type Animal struct {
 }
 ```
 
-If you have defined a default value in the `sql` tag, the generated create SQl will ignore these fields if it is blank.
+If you have defined a default value in the `sql` tag, the generated create SQL will ignore these fields if it is blank.
 
 Eg.
 


### PR DESCRIPTION
Just a small fix I have seen while reading through the docs.