### PR TITLE
Fix SqlTag() in case of ByteSlice

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -53,7 +53,7 @@ func (postgres) SqlTag(value reflect.Value, size int, autoIncrease bool) string 
 			return "hstore"
 		}
 	default:
-		if isByteArray(value) {
+		if isByteArrayOrSlice(value) {
 			if isUUID(value) {
 				return "uuid"
 			}
@@ -65,8 +65,8 @@ func (postgres) SqlTag(value reflect.Value, size int, autoIncrease bool) string 
 
 var byteType = reflect.TypeOf(uint8(0))
 
-func isByteArray(value reflect.Value) bool {
-	return value.Kind() == reflect.Array && value.Type().Elem() == byteType
+func isByteArrayOrSlice(value reflect.Value) bool {
+	return (value.Kind() == reflect.Array || value.Kind() == reflect.Slice) && value.Type().Elem() == byteType
 }
 
 func isUUID(value reflect.Value) bool {


### PR DESCRIPTION
Before https://github.com/jinzhu/gorm/commit/3cb95264dff572434ed72977d78f16ab4fe1dc83,
SqlTag() returns "bytea" for []byte FIeld with no tag.

For example,
```
type Model struct {
   Field [] byte
}
```

After https://github.com/jinzhu/gorm/commit/3cb95264dff572434ed72977d78f16ab4fe1dc83,
SqlTag() returns error if not specifying explicit tag.
