### PR TITLE
Break [] byte, I was breaking another case

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -54,10 +54,9 @@ func (postgres) SqlTag(value reflect.Value, size int, autoIncrease bool) string 
 		}
 	default:
 		if isByteArrayOrSlice(value) {
-			if isUUID(value) {
-				return "uuid"
-			}
 			return "bytea"
+		} else if isUUID(value) {
+			return "uuid"
 		}
 	}
 	panic(fmt.Sprintf("invalid sql type %s (%s) for postgres", value.Type().Name(), value.Kind().String()))


### PR DESCRIPTION
this PR #706 broken another case
Example: 
EncryptedPassword []byte  `json:"-" sql:"encrypted_password;not null"`