### PR TITLE
Enable to decline antuincrement on ID field

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -435,9 +435,12 @@ func (scope *Scope) generateSqlTag(field *StructField) string {
 			size, _ = strconv.Atoi(value)
 		}
 
-		_, autoIncrease := sqlSettings["AUTO_INCREMENT"]
+		v, autoIncrease := sqlSettings["AUTO_INCREMENT"]
 		if field.IsPrimaryKey {
 			autoIncrease = true
+		}
+		if v == "NO" {
+			autoIncrease = false
 		}
 
 		sqlType = scope.Dialect().SqlTag(reflectValue, size, autoIncrease)


### PR DESCRIPTION
@jinzhu 

Thank you always for this useful library. It's very helpful for daily work and also my private work.

# request

These days, I faced to data model with `ID` field (it is `ID` actually, semantically) but it's not-zero-origin  and not-sequential.

I want to name this field `ID` but not want to be auto-incremental.

# solution

I found your code is already extensible enough! So I modified `generateSqlTag` func a bit. In this pull-request, I use `NO` for adhoc spell, but it's just an idea.

Please tell me your idea, or I'm very glad if you merge this request. 

Thank you

----

- [x] go test ./...
- [ ] review