### PR TITLE
Fix update of fields with a default value

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -197,4 +197,10 @@ func (c *callback) sort() {
 	c.rowQueries = sortProcessors(rowQueries)
 }
 
+func ForceReload(scope *Scope) {
+	if _, ok := scope.InstanceGet("gorm:force_reload"); ok {
+		scope.DB().New().First(scope.Value)
+	}
+}
+
 var DefaultCallback = &callback{processors: []*callbackProcessor{}}

--- a/callback_create.go
+++ b/callback_create.go
@@ -33,7 +33,7 @@ func Create(scope *Scope) {
 							columns = append(columns, scope.Quote(field.DBName))
 							sqls = append(sqls, scope.AddToVars(field.Field.Interface()))
 						} else if field.HasDefaultValue {
-							scope.InstanceSet("gorm:force_reload_after_create", true)
+							scope.InstanceSet("gorm:force_reload", true)
 						}
 					}
 				} else if relationship := field.Relationship; relationship != nil && relationship.Kind == "belongs_to" {
@@ -97,12 +97,6 @@ func Create(scope *Scope) {
 	}
 }
 
-func ForceReloadAfterCreate(scope *Scope) {
-	if _, ok := scope.InstanceGet("gorm:force_reload_after_create"); ok {
-		scope.DB().New().First(scope.Value)
-	}
-}
-
 func AfterCreate(scope *Scope) {
 	scope.CallMethodWithErrorCheck("AfterCreate")
 	scope.CallMethodWithErrorCheck("AfterSave")
@@ -114,7 +108,7 @@ func init() {
 	DefaultCallback.Create().Register("gorm:save_before_associations", SaveBeforeAssociations)
 	DefaultCallback.Create().Register("gorm:update_time_stamp_when_create", UpdateTimeStampWhenCreate)
 	DefaultCallback.Create().Register("gorm:create", Create)
-	DefaultCallback.Create().Register("gorm:force_reload_after_create", ForceReloadAfterCreate)
+	DefaultCallback.Create().Register("gorm:force_reload", ForceReload)
 	DefaultCallback.Create().Register("gorm:save_after_associations", SaveAfterAssociations)
 	DefaultCallback.Create().Register("gorm:after_create", AfterCreate)
 	DefaultCallback.Create().Register("gorm:commit_or_rollback_transaction", CommitOrRollbackTransaction)

--- a/scope.go
+++ b/scope.go
@@ -411,7 +411,7 @@ func (scope *Scope) OmitAttrs() []string {
 	return scope.Search.omits
 }
 
-func (scope *Scope) changeableDBColumn(column string) bool {
+func (scope *Scope) isChangeableDBColumn(column string) bool {
 	selectAttrs := scope.SelectAttrs()
 	omitAttrs := scope.OmitAttrs()
 

--- a/update_test.go
+++ b/update_test.go
@@ -101,7 +101,6 @@ func TestUpdateWithNoStdPrimaryKeyAndDefaultValues(t *testing.T) {
 
 	animal = Animal{From: "somewhere"}              // No name fields, should be filled with the default value (galeone)
 	DB.Save(&animal).Update("From", "a nice place") // The name field shoul be untouched
-	DB.First(&animal, animal.Counter)
 	if animal.Name != "galeone" {
 		t.Errorf("Name fiels shouldn't be changed if untouched, but got %v", animal.Name)
 	}
@@ -109,17 +108,15 @@ func TestUpdateWithNoStdPrimaryKeyAndDefaultValues(t *testing.T) {
 	// When changing a field with a default value, the change must occur
 	animal.Name = "amazing horse"
 	DB.Save(&animal)
-	DB.First(&animal, animal.Counter)
 	if animal.Name != "amazing horse" {
 		t.Errorf("Update a filed with a default value should occur. But got %v\n", animal.Name)
 	}
 
-	// When changing a field with a default value with blank value
+	// When changing a field with a default value with blank value, the DBMS should insert the default value. Not the empty one.
 	animal.Name = ""
 	DB.Save(&animal)
-	DB.First(&animal, animal.Counter)
-	if animal.Name != "" {
-		t.Errorf("Update a filed to blank with a default value should occur. But got %v\n", animal.Name)
+	if animal.Name == "" {
+		t.Errorf("Update a filed with an associated default value should not occur when trying to insert an empty field. The default one should be inserted\n")
 	}
 }
 


### PR DESCRIPTION
Thix PR fixes https://github.com/jinzhu/gorm/issues/731 and https://github.com/jinzhu/gorm/issues/730

As I specified in this comment: https://github.com/jinzhu/gorm/commit/2a46856d5238837a5f65f4a05181a6685335a4af#commitcomment-14500486

When an update is done on a field with an associated default value, and the update set this field to blank, gorm do the right thing (as it was before, when I create the default value support).