### PR TITLE
Fix update of fields with a default value

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -29,12 +29,15 @@ func Create(scope *Scope) {
 			if scope.changeableField(field) {
 				if field.IsNormal {
 					if !field.IsPrimaryKey || (field.IsPrimaryKey && !field.IsBlank) {
-						if !field.IsBlank || !field.HasDefaultValue {
+						if !field.HasDefaultValue {
 							columns = append(columns, scope.Quote(field.DBName))
 							sqls = append(sqls, scope.AddToVars(field.Field.Interface()))
-						} else if field.HasDefaultValue {
+						} else {
+							columns = append(columns, scope.Quote(field.DBName))
+							sqls = append(sqls, handleDefaultValue(scope, field))
 							scope.InstanceSet("gorm:force_reload", true)
 						}
+
 					}
 				} else if relationship := field.Relationship; relationship != nil && relationship.Kind == "belongs_to" {
 					for _, dbName := range relationship.ForeignDBNames {

--- a/create_test.go
+++ b/create_test.go
@@ -157,3 +157,25 @@ func TestOmitWithCreate(t *testing.T) {
 		t.Errorf("Should not create omited relationships")
 	}
 }
+
+// Test from: https://github.com/jinzhu/gorm/issues/689
+func TestCreateWithBoolDefaultValue(t *testing.T) {
+	type Data struct {
+		ID            int    `gorm:"column:id;primary_key" json:"id"`
+		Name          string `sql:"type:varchar(100);not null;unique" json:"name"`
+		DeleteAllowed bool   `sql:"not null;DEFAULT:true" json:"delete_allowed"`
+	}
+
+	DB.AutoMigrate(&Data{})
+
+	data := Data{
+		Name:          "test",
+		DeleteAllowed: false,
+	}
+
+	DB.Create(&data)
+
+	if data.DeleteAllowed {
+		t.Error("Test failed")
+	}
+}

--- a/create_test.go
+++ b/create_test.go
@@ -51,7 +51,7 @@ func TestCreate(t *testing.T) {
 
 	DB.Model(user).Update("name", "create_user_new_name")
 	DB.First(&user, user.Id)
-	if user.CreatedAt != newUser.CreatedAt {
+	if user.CreatedAt.Format(time.RFC3339Nano) != newUser.CreatedAt.Format(time.RFC3339Nano) {
 		t.Errorf("CreatedAt should not be changed after update")
 	}
 }

--- a/structs_test.go
+++ b/structs_test.go
@@ -134,6 +134,7 @@ type Animal struct {
 	unexported string    // unexported value
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
+	Cool       bool `sql:"default:false"`
 }
 
 type JoinTable struct {

--- a/update_test.go
+++ b/update_test.go
@@ -87,10 +87,11 @@ func TestUpdateWithNoStdPrimaryKeyAndDefaultValues(t *testing.T) {
 	DB.Save(&animal)
 	updatedAt1 := animal.UpdatedAt
 
+	// Sleep for a second and than update a field
+	time.Sleep(1000 * time.Millisecond)
 	DB.Save(&animal).Update("name", "Francis")
-
 	if updatedAt1.Format(time.RFC3339Nano) == animal.UpdatedAt.Format(time.RFC3339Nano) {
-		t.Errorf("updatedAt should not be updated if nothing changed")
+		t.Errorf("updatedAt should be updated when changing a field")
 	}
 
 	var animals []Animal
@@ -117,6 +118,19 @@ func TestUpdateWithNoStdPrimaryKeyAndDefaultValues(t *testing.T) {
 	DB.Save(&animal)
 	if animal.Name == "" {
 		t.Errorf("Update a filed with an associated default value should not occur when trying to insert an empty field. The default one should be inserted\n")
+	}
+
+	// Animal.Cool has a default value thats equal to the Zero of its type. (false) I have to update this field to true and false without problems
+	animal.Cool = true
+	DB.Save(&animal)
+	if !animal.Cool {
+		t.Errorf("I should update a field with a default value to someother value")
+	}
+
+	animal.Cool = false
+	DB.Save(&animal)
+	if animal.Cool {
+		t.Errorf("I should update a field with an associated blank value to its blank value")
 	}
 }
 


### PR DESCRIPTION
Now we can deal with the update of field having a default value even if this value is the "blank" value.

For example.
```gp
 type Animal struct {
     // ... see the changes in the tests
     Cool       bool `sql:"default:false"`
 }
```

This struct have a default value for the boolean attribute, that's equals to the Zero value of the boolean type.

Now we can set without any problem the `Cool` attribute to true or to false (when is false is replaced with the default value of the tag field).

Referring to my comment in #735:

What I want `UPDATE comments SET message = 'edited' WHERE id = 9`

Now what I get: `UPDATE comments SET message = 'edited', "time" = (now() at time zone 'utc') WHERE id = 9`

that's better of what I previously wanted, since I can see the default value being inserted in the query and is more clear to read and understand.

I get this query because the declaration of the Time field is `Time time.Time `sql:"default:(now() at time zone 'utc')".

P.S: I tough I could use the sql syntax `set field=DEFAULT` but that's not supported in DBMS like `sqlite3`, thus I fallback to this solution that works well with every DBMS.

Regards