### PR TITLE
provide user with more descriptive error message

### DIFF
--- a/field.go
+++ b/field.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"reflect"
 )
 
@@ -44,7 +45,7 @@ func (field *Field) Set(value interface{}) error {
 		if reflectValue.Type().ConvertibleTo(field.Field.Type()) {
 			field.Field.Set(reflectValue.Convert(field.Field.Type()))
 		} else {
-			return errors.New("could not convert argument")
+			return fmt.Errorf("could not convert argument of field %s from %s to %s", field.Name, reflectValue.Type(), field.Field.Type())
 		}
 	}
 


### PR DESCRIPTION
provide user with information about which field can't be converted and the types involved