### PR TITLE
Give (*ModelStruct).TableName() a pointer receiver

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -48,7 +48,7 @@ type ModelStruct struct {
 	cached           bool
 }
 
-func (s ModelStruct) TableName(db *DB) string {
+func (s *ModelStruct) TableName(db *DB) string {
 	return DefaultTableNameHandler(db, s.defaultTableName)
 }
 


### PR DESCRIPTION
There was a data race caused by the copy of the ModelStruct. See #723.

Fixes #723.