### PR TITLE
scope: Catch error for db.Commit()

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -380,7 +380,7 @@ func (scope *Scope) CommitOrRollback() *Scope {
 			if scope.HasError() {
 				db.Rollback()
 			} else {
-				db.Commit()
+				scope.Err(db.Commit())
 			}
 			scope.db.db = scope.db.parent.db
 		}


### PR DESCRIPTION
db.Commit() will return error but it is ignored.
We find this problem in this issue https://github.com/pingcap/tidb/issues/822.