### PR TITLE
Fixes unexpected keyname bug in addForeignKey function

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -607,7 +607,7 @@ func (scope *Scope) addIndex(unique bool, indexName string, column ...string) {
 }
 
 func (scope *Scope) addForeignKey(field string, dest string, onDelete string, onUpdate string) {
-	var keyName = fmt.Sprintf("%s_%s_%s_foreign", scope.TableName(), field, dest, "_")
+	var keyName = fmt.Sprintf("%s_%s_%s_foreign", scope.TableName(), field, dest)
 	keyName = regexp.MustCompile("(_*[^a-zA-Z]+_*|_+)").ReplaceAllString(keyName, "_")
 	var query = `ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s ON DELETE %s ON UPDATE %s;`
 	scope.Raw(fmt.Sprintf(query, scope.QuotedTableName(), scope.QuoteIfPossible(keyName), scope.QuoteIfPossible(field), dest, onDelete, onUpdate)).Exec()


### PR DESCRIPTION
Fixes wrong number of args for format in Sprintf call bug in addForeignKey function

```
pq: constraint "share_reports_share_id_shares_foreign_extra_string_" for relation "share_reports" already exists
```

Got unexpected constraint foreign key name `share_reports_share_id_shares_foreign_extra_string_`, want `share_reports_share_id_shares_foreign`.