### PR TITLE
README: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ type User struct {
 
 type CreditCard struct {
 	gorm.Model
-	UesrID   uint
+	UserID   uint
 	Number   string
 }
 


### PR DESCRIPTION
Fix typo in has-one example.