### PR TITLE
Fix polymorphic test

### DIFF
--- a/polymorphic_test.go
+++ b/polymorphic_test.go
@@ -44,7 +44,7 @@ func TestPolymorphic(t *testing.T) {
 		t.Errorf("Cat's toys count should be 1")
 	}
 
-	if DB.Model(&cat).Association("Toy").Count() != 1 {
+	if DB.Model(&dog).Association("Toys").Count() != 2 {
 		t.Errorf("Dog's toys count should be 2")
 	}
 


### PR DESCRIPTION
One assertion comment says look for association with dog but the code
still uses cat. This aligns the code to now look at the association of
the dog.