### PR TITLE
Fixes querying with inline map when a value is nil

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -31,7 +31,11 @@ func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str stri
 	case map[string]interface{}:
 		var sqls []string
 		for key, value := range value {
-			sqls = append(sqls, fmt.Sprintf("(%v = %v)", scope.Quote(key), scope.AddToVars(value)))
+			if value != nil {
+				sqls = append(sqls, fmt.Sprintf("(%v = %v)", scope.Quote(key), scope.AddToVars(value)))
+			} else {
+				sqls = append(sqls, fmt.Sprintf("(%v IS NULL)", scope.Quote(key)))
+			}
 		}
 		return strings.Join(sqls, " AND ")
 	case interface{}:
@@ -97,7 +101,11 @@ func (scope *Scope) buildNotCondition(clause map[string]interface{}) (str string
 	case map[string]interface{}:
 		var sqls []string
 		for key, value := range value {
-			sqls = append(sqls, fmt.Sprintf("(%v <> %v)", scope.Quote(key), scope.AddToVars(value)))
+			if value != nil {
+				sqls = append(sqls, fmt.Sprintf("(%v <> %v)", scope.Quote(key), scope.AddToVars(value)))
+			} else {
+				sqls = append(sqls, fmt.Sprintf("(%v IS NOT NULL)", scope.Quote(key)))
+			}
 		}
 		return strings.Join(sqls, " AND ")
 	case interface{}:


### PR DESCRIPTION
Previously, querying with an inline map created 'where conditions' which always used the equality operator for comparison. This is problematic when trying to compare find records which are `NULL`.

This changes the inline map query build condition to use `IS NULL` instead of the equality operator when the provided value is `nil`. The inverse `NOT` has also been update to produce an `IS NOT NULL` condition.