### PR TITLE
Fixed an issue with reflect.Value.FieldByName causing panic

### DIFF
--- a/preload.go
+++ b/preload.go
@@ -186,6 +186,9 @@ func (scope *Scope) handleBelongsToPreload(field *Field, conditions []interface{
 			objects := scope.IndirectValue()
 			for j := 0; j < objects.Len(); j++ {
 				object := reflect.Indirect(objects.Index(j))
+				if object.Kind() == reflect.Ptr {
+					object = reflect.Indirect(objects.Index(j).Elem())
+				}
 				if equalAsString(getRealValue(object, relation.ForeignFieldNames), value) {
 					object.FieldByName(field.Name).Set(result)
 				}
@@ -312,7 +315,11 @@ func (scope *Scope) getColumnAsArray(columns []string) (results [][]interface{})
 		for i := 0; i < values.Len(); i++ {
 			var result []interface{}
 			for _, column := range columns {
-				result = append(result, reflect.Indirect(values.Index(i)).FieldByName(column).Interface())
+				value := reflect.Indirect(values.Index(i))
+				if value.Kind() == reflect.Ptr {
+					value = reflect.Indirect(values.Index(i).Elem())
+				}
+				result = append(result, value.FieldByName(column).Interface())
 			}
 			results = append(results, result)
 		}


### PR DESCRIPTION
There is an issue with preload functionality where FieldByName causes panic when your models are structured in a certain way.

It happens when doing a nested preload when some objects have relations you are trying to preload but some don't.

Here is an example script which causes panic.

This line fails:

`db.Preload("UserProfiles.Profile")`

```go
package main

import (
	"database/sql"
	"log"

	_ "github.com/go-sql-driver/mysql"
	"github.com/jinzhu/gorm"
	_ "github.com/lib/pq"
	_ "github.com/mattn/go-sqlite3"
)

var db gorm.DB

// Profile ...
type Profile struct {
	gorm.Model
	Name string `sql:"type:varchar(40);not null"`
}

// User ...
type User struct {
	gorm.Model
	Username     string `sql:"type:varchar(100);not null;unique"`
	UserProfiles []*UserProfile
}

// UserProfile ...
type UserProfile struct {
	gorm.Model
	ProfileID sql.NullInt64 `sql:"index;not null"`
	UserID    sql.NullInt64 `sql:"index;not null"`
	Profile   *Profile
	User      *User
	State     string `sql:"index;not null"`
}

func init() {
	var err error
	db, err = gorm.Open("sqlite3", ":memory:")
	// db, err := gorm.Open("postgres", "user=username dbname=password sslmode=disable")
	// db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True")
	if err != nil {
		panic(err)
	}
	db.LogMode(true)

	db.AutoMigrate(new(Profile), new(User), new(UserProfile))
}

func main() {
	buyerProfile := &Profile{Name: "buyer"}
	if err := db.Create(buyerProfile).Error; err != nil {
		panic(err)
	}
	sellerProfile := &Profile{Name: "seller"}
	if err := db.Create(sellerProfile).Error; err != nil {
		panic(err)
	}

	user1 := &User{
		Username: "username_1",
		UserProfiles: []*UserProfile{
			&UserProfile{
				Profile: buyerProfile,
				State:   "some_state",
			},
		},
	}
	if err := db.Create(user1).Error; err != nil {
		panic(err)
	}

	user2 := &User{
		Username: "username_2",
		UserProfiles: []*UserProfile{
			&UserProfile{
				Profile: sellerProfile,
				State:   "some_state",
			},
		},
	}
	if err := db.Create(user2).Error; err != nil {
		panic(err)
	}

	user3 := &User{
		Username: "username_3",
	}
	if err := db.Create(user3).Error; err != nil {
		panic(err)
	}

	users := make([]*User, 0)

	if err := db.Preload("UserProfiles.Profile").Find(&users).Error; err != nil {
		log.Fatal(err)
	}

	for _, user := range users {
		log.Print(user)
	}
}
```