### PR TITLE
Handle string as primary key

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -21,7 +21,11 @@ func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str stri
 		if regexp.MustCompile("^\\s*\\d+\\s*$").MatchString(value) {
 			return scope.primaryCondition(scope.AddToVars(value))
 		} else if value != "" {
-			str = fmt.Sprintf("(%v)", value)
+			if regexp.MustCompile("^[a-zA-Z0-9]+$").MatchString(value) {
+				return scope.primaryCondition(scope.AddToVars(value))
+			} else {
+				str = fmt.Sprintf("(%v)", value)
+			}
 		}
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, sql.NullInt64:
 		return scope.primaryCondition(scope.AddToVars(value))


### PR DESCRIPTION
After having issues with a `String` as **PRIMARY KEY** using **Postgres** here is a proposition of fix. (I'm not sure it's the right way to do it so feel free to put me in the right direction).

#### Issue Example ####
```
type User struct {
	UserID    string `gorm:"user_id;primary_key"`
	Name      string
	CreatedAt time.Time
	UpdatedAt time.Time
}

func main() {
	db, err := gorm.Open("postgres", "user=username dbname=password sslmode=disable")
	if err != nil {
		panic(err)
	}
	db.LogMode(true)

	var u User
	if ret := db.First(&u, "qwertyu"); ret != nil && ret.Error != nil {
		log.Println(ret.Error) // Display `ERROR:  column "qwertyu" does not exist at character 31`
	}
	log.Println(u)
}
```

The instruction `db.First(&u, "qwertyu")` was generating the following **failing** request `SELECT  * FROM "users"  WHERE (qwertyu) LIMIT 1`
With the fix it's now generating `SELECT  * FROM "users"  WHERE (user_id = 'qwertyu') LIMIT 1`

*Note: I'm not sure what are the characters we should support in a* `String` **PRIMARY KEY** *so we might need to change the regular expression for `"^\\w+$"` (`[0-9A-Za-z_]`)*

#### Testing ####
The tests does fail on **master**
```
--- FAIL: TestNestedPreload10 (0.01s)
panic: reflect: call of reflect.Value.FieldByName on ptr Value [recovered]
	panic: reflect: call of reflect.Value.FieldByName on ptr Value
```
so I'm not able to know if it's breaking anything but it runs well on my own solution tests (Which doesn't cover everything though)

Hope that helps.
Cheers,