### PR TITLE
Remove regex guess on counting query

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -220,8 +220,6 @@ func (scope *Scope) whereSql() (sql string) {
 	return
 }
 
-var hasCountRegexp = regexp.MustCompile(`(?i)count\(.+\)`)
-
 func (scope *Scope) selectSql() string {
 	if len(scope.Search.selects) == 0 {
 		if scope.Search.joins != "" {
@@ -229,9 +227,7 @@ func (scope *Scope) selectSql() string {
 		}
 		return "*"
 	}
-	sql := scope.buildSelectQuery(scope.Search.selects)
-	scope.Search.countingQuery = (len(scope.Search.group) == 0) && hasCountRegexp.MatchString(sql)
-	return sql
+	return scope.buildSelectQuery(scope.Search.selects)
 }
 
 func (scope *Scope) orderSql() string {
@@ -416,6 +412,7 @@ func (scope *Scope) pluck(column string, value interface{}) *Scope {
 
 func (scope *Scope) count(value interface{}) *Scope {
 	scope.Search.Select("count(*)")
+	scope.Search.countingQuery = true
 	scope.Err(scope.row().Scan(value))
 	return scope
 }


### PR DESCRIPTION
The hasCountRegexp and check in the selectSql was causing issues on queries with embedded count(*) in them.  For example, a query in the following format will fail to act as expected -

db.Table("table1").Select("*, (select count(*) from table2 where table1.id = table2.id)").Order("table1.name")

The sql generated will not include the order by clause, but will also not generate any errors.

The new behavior is that the query will attempt to run exactly as the developer entered it - if it is invalid, the developer will receive an error.  If the developer uses the built in gorm Count() method, any order by clauses will be ignored, and the correct count will be returned.