### PR TITLE
Fix README typo on Related usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ db.Model(&user).Related(&card, "CreditCard")
 //// SELECT * FROM credit_cards WHERE user_id = 123; // 123 is user's primary key
 // CreditCard is user's field name, it means get user's CreditCard relations and fill it into variable card
 // If the field name is same as the variable's type name, like above example, it could be omitted, like:
-db.Model(&user).Related(&creditCard, "CreditCard")
+db.Model(&user).Related(&card)
 ```
 
 ### Belongs To


### PR DESCRIPTION
Fix a minor typo when showing Related usage with field name omit, so it doesn't confuse new users.