### PR TITLE
Fix documentation for Count() function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,7 +859,7 @@ db.Where("name = ?", "jinzhu").Or("name = ?", "jinzhu 2").Find(&users).Count(&co
 //// SELECT * from USERS WHERE name = 'jinzhu' OR name = 'jinzhu 2'; (users)
 //// SELECT count(*) FROM users WHERE name = 'jinzhu' OR name = 'jinzhu 2'; (count)
 
-db.Model(User{}).Where("name = ?", "jinzhu").Count(&count)
+db.Model(&User{}).Where("name = ?", "jinzhu").Count(&count)
 //// SELECT count(*) FROM users WHERE name = 'jinzhu'; (count)
 
 db.Table("deleted_users").Count(&count)


### PR DESCRIPTION
Hi,

One of your Count function examples causes a panic for me on Go 1.5.3. For example:

```go
a.db.Find(Sms{}).Count(&count)
```

Changing this to a pointer to the struct fixes the problem:

```go
a.db.Find(&Sms{}).Count(&count)
```

This PR updates the documentation to show a pointer to the struct instead.
