### PR TITLE
Removed guessing numeric type from a string.

### DIFF
--- a/scope_private.go
+++ b/scope_private.go
@@ -17,10 +17,7 @@ func (scope *Scope) primaryCondition(value interface{}) string {
 func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str string) {
 	switch value := clause["query"].(type) {
 	case string:
-		// if string is number
-		if regexp.MustCompile("^\\s*\\d+\\s*$").MatchString(value) {
-			return scope.primaryCondition(scope.AddToVars(value))
-		} else if value != "" {
+		if value != "" {
 			str = fmt.Sprintf("(%v)", value)
 		}
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, sql.NullInt64:


### PR DESCRIPTION
This type of guess work is dangerous. It could lead to the situation where input is accepted from a query string for an primary key query, but is injected into the SQL string directly.

/api/user/10
db.Find(&user, "10")  // SELECT * FROM users WHERE id = 10;

/api/user/1=1
db.Find(&user, "1=1")  // SELECT * FROM users WHERE "1=1";

which is equivalent to 
// SELECT * FROM users

It shouldn't behave differently based on the content of the string passed to it. Especially when that has a security implication. If the user want's to pass a int, they should pass that type.