### PR TITLE
Fix a reflection panic with nested preloads

### DIFF
--- a/preload.go
+++ b/preload.go
@@ -157,6 +157,9 @@ func (scope *Scope) handleHasManyPreload(field *Field, conditions []interface{})
 			for j := 0; j < objects.Len(); j++ {
 				object := reflect.Indirect(objects.Index(j))
 				if equalAsString(getRealValue(object, relation.AssociationForeignFieldNames), value) {
+					if object.Kind() == reflect.Ptr {
+						object = object.Elem()
+					}
 					f := object.FieldByName(field.Name)
 					f.Set(reflect.Append(f, result))
 					break


### PR DESCRIPTION
Fix the following reflection panic when using nested preload:
```
➜  gorm git:(master) ✗ go test -test.v -test.run TestNestedManyToManyPreload3
testing sqlite3...

(no such table: animals) 
[2016-02-04 21:12:10]  

(no such table: users) 
[2016-02-04 21:12:10]  
=== RUN   TestNestedManyToManyPreload3
--- FAIL: TestNestedManyToManyPreload3 (0.06s)
panic: reflect: call of reflect.Value.FieldByName on ptr Value [recovered]
	panic: reflect: call of reflect.Value.FieldByName on ptr Value

goroutine 21 [running]:
testing.tRunner.func1(0xc82012f0e0)
	/usr/local/go/src/testing/testing.go:450 +0x171
reflect.flag.mustBe(0xd6, 0x19)
	/usr/local/go/src/reflect/value.go:199 +0xa6
reflect.Value.FieldByName(0x868660, 0xc8204eaf78, 0xd6, 0x99e580, 0x7, 0x0, 0x0, 0x0)
	/usr/local/go/src/reflect/value.go:788 +0x53
github.com/jinzhu/gorm.(*Scope).handleHasManyPreload(0xc8207c8f00, 0xc8207d3b00, 0x0, 0x0, 0x0)
	/home/akabane/work/src/github.com/jinzhu/gorm/preload.go:163 +0x8f4
github.com/jinzhu/gorm.Preload(0xc8207c8600)
	/home/akabane/work/src/github.com/jinzhu/gorm/preload.go:67 +0xba5
github.com/jinzhu/gorm.(*Scope).callCallbacks(0xc8207c8600, 0xc8201315c0, 0x3, 0x4, 0xc8207c8600)
	/home/akabane/work/src/github.com/jinzhu/gorm/scope_private.go:331 +0x68
github.com/jinzhu/gorm.(*DB).First(0xc8207cee60, 0x867a00, 0xc8207d2360, 0x0, 0x0, 0x0, 0xc8207cee60)
	/home/akabane/work/src/github.com/jinzhu/gorm/main.go:204 +0x236
github.com/jinzhu/gorm_test.TestNestedManyToManyPreload3(0xc82012f0e0)
	/home/akabane/work/src/github.com/jinzhu/gorm/preload_test.go:1131 +0xdb8
testing.tRunner(0xc82012f0e0, 0xec9108)
	/usr/local/go/src/testing/testing.go:456 +0x98
created by testing.RunTests
	/usr/local/go/src/testing/testing.go:561 +0x86d

goroutine 1 [chan receive]:
testing.RunTests(0xa6bfc0, 0xec89a0, 0x75, 0x75, 0x9a5001)
	/usr/local/go/src/testing/testing.go:562 +0x8ad
testing.(*M).Run(0xc8205f9ee8, 0x8ebc00)
	/usr/local/go/src/testing/testing.go:494 +0x70
main.main()
	github.com/jinzhu/gorm/_test/_testmain.go:292 +0x116

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1721 +0x1

goroutine 34 [chan receive]:
database/sql.(*DB).connectionOpener(0xc8200cc1e0)
	/usr/local/go/src/database/sql/sql.go:634 +0x45
created by database/sql.Open
	/usr/local/go/src/database/sql/sql.go:481 +0x336
exit status 2
FAIL	github.com/jinzhu/gorm	0.300
```