### PR TITLE
Fixed a nested preload panic bug.

### DIFF
--- a/preload.go
+++ b/preload.go
@@ -294,6 +294,9 @@ func (scope *Scope) handleManyToManyPreload(field *Field, conditions []interface
 		objects := scope.IndirectValue()
 		for j := 0; j < objects.Len(); j++ {
 			object := reflect.Indirect(objects.Index(j))
+			if object.Kind() == reflect.Ptr {
+				object = object.Elem()
+			}
 			source := getRealValue(object, foreignFieldNames)
 			field := object.FieldByName(field.Name)
 			for _, link := range linkHash[toString(source)] {


### PR DESCRIPTION
Fixed another nested preload bug I encountered.

There might be more bugs similar to this one, basically every time you try to do:

```
object.FieldByName
```

You should first check if `object` is a pointer:

```
if object.Kind() == reflect.Ptr {
	object = object.Elem()
}
```

I have also refactored a test from my previous PR a bit.