### PR TITLE
HasTable now works with table name passed as a string.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -165,11 +165,23 @@ func TestHasTable(t *testing.T) {
 		Stuff string
 	}
 	DB.DropTable(&Foo{})
+
+	// Table should not exist at this point, HasTable should return false
+	if ok := DB.HasTable("foos"); ok {
+		t.Errorf("Table should not exist, but does")
+	}
 	if ok := DB.HasTable(&Foo{}); ok {
 		t.Errorf("Table should not exist, but does")
 	}
+
+	// We create the table
 	if err := DB.CreateTable(&Foo{}).Error; err != nil {
 		t.Errorf("Table should be created")
+	}
+
+	// And now it should exits, and HasTable should return true
+	if ok := DB.HasTable("foos"); !ok {
+		t.Errorf("Table should exist, but HasTable informs it does not")
 	}
 	if ok := DB.HasTable(&Foo{}); !ok {
 		t.Errorf("Table should exist, but HasTable informs it does not")

--- a/scope.go
+++ b/scope.go
@@ -267,6 +267,10 @@ type dbTabler interface {
 
 // TableName get table name
 func (scope *Scope) TableName() string {
+	if strTableName, ok := scope.Value.(string); ok {
+		return strTableName
+	}
+
 	if scope.Search != nil && len(scope.Search.tableName) > 0 {
 		return scope.Search.tableName
 	}


### PR DESCRIPTION
Before, only HasTable(&Foo) would work but HasTable("foos") would always
return false. This PR fixes that.