### PR TITLE
Consider migrating schema in Getting Started Guide

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -53,6 +53,9 @@ func main() {
     panic("failed to connect database")
   }
 
+  // Migrate the schema
+  db.AutoMigrate(&Product{})
+  
   // Create
   db.Create(&Product{Code: "L1212", Price: 1000})
 


### PR DESCRIPTION
The GORM Getting Started guide has a helpful code example. However, the example lacks initial schema migration and when run for the first time will error out with 

```
(no such table: products) 
[2016-04-29 11:54:09]  

(no such table: products) 
[2016-04-29 11:54:09]  

(no such table: products) 
[2016-04-29 11:54:09]  

(no such table: products) 
[2016-04-29 11:54:09]  

```
The proposed change resolves the error and ensures that the Getting Started example will successfully read from and write to the database.

