### PR TITLE
association: dont execute Append/Replace/Delete if Error already present

### DIFF
--- a/association.go
+++ b/association.go
@@ -22,6 +22,10 @@ func (association *Association) Find(value interface{}) *Association {
 
 // Append append new associations for many2many, has_many, replace current association for has_one, belongs_to
 func (association *Association) Append(values ...interface{}) *Association {
+	if association.Error != nil {
+		return association
+	}
+
 	if relationship := association.field.Relationship; relationship.Kind == "has_one" {
 		return association.Replace(values...)
 	}
@@ -30,6 +34,10 @@ func (association *Association) Append(values ...interface{}) *Association {
 
 // Replace replace current associations with new one
 func (association *Association) Replace(values ...interface{}) *Association {
+	if association.Error != nil {
+		return association
+	}
+
 	var (
 		relationship = association.field.Relationship
 		scope        = association.scope
@@ -118,6 +126,10 @@ func (association *Association) Replace(values ...interface{}) *Association {
 
 // Delete remove relationship between source & passed arguments, but won't delete those arguments
 func (association *Association) Delete(values ...interface{}) *Association {
+	if association.Error != nil {
+		return association
+	}
+
 	var (
 		relationship = association.field.Relationship
 		scope        = association.scope


### PR DESCRIPTION
Prevents panics if associations are used as described in the docs but an error happened beforehand. (Like missing ID or something since the model wasn't saved yet.)

Not in `(a *Association) Count() int` since, well, int. Ideas? Why does this work differently then the other `Count()`s anyway? (Returning an int instead of writing to a pointer)