### PR TITLE
Only set autoincrement if the tag is used. Fixes #1002

### DIFF
--- a/customize_column_test.go
+++ b/customize_column_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type CustomizeColumn struct {
-	ID   int64     `gorm:"column:mapped_id; primary_key:yes"`
+	ID   int64     `gorm:"column:mapped_id; primary_key:yes; AUTO_INCREMENT"`
 	Name string    `gorm:"column:mapped_name"`
 	Date time.Time `gorm:"column:mapped_time"`
 }
@@ -67,12 +67,12 @@ func TestCustomColumnAndIgnoredFieldClash(t *testing.T) {
 }
 
 type CustomizePerson struct {
-	IdPerson string             `gorm:"column:idPerson;primary_key:true"`
+	IdPerson string             `gorm:"column:idPerson;primary_key:true;AUTO_INCREMENT"`
 	Accounts []CustomizeAccount `gorm:"many2many:PersonAccount;associationforeignkey:idAccount;foreignkey:idPerson"`
 }
 
 type CustomizeAccount struct {
-	IdAccount string `gorm:"column:idAccount;primary_key:true"`
+	IdAccount string `gorm:"column:idAccount;primary_key:true;AUTO_INCREMENT"`
 	Name      string
 }
 

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -32,28 +32,28 @@ func (mysql) DataTypeOf(field *StructField) string {
 		case reflect.Bool:
 			sqlType = "boolean"
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
-			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "int AUTO_INCREMENT"
 			} else {
 				sqlType = "int"
 			}
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
-			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "int unsigned AUTO_INCREMENT"
 			} else {
 				sqlType = "int unsigned"
 			}
 		case reflect.Int64:
-			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "bigint AUTO_INCREMENT"
 			} else {
 				sqlType = "bigint"
 			}
 		case reflect.Uint64:
-			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "bigint unsigned AUTO_INCREMENT"
 			} else {

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -31,14 +31,14 @@ func (postgres) DataTypeOf(field *StructField) string {
 		case reflect.Bool:
 			sqlType = "boolean"
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
-			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "serial"
 			} else {
 				sqlType = "integer"
 			}
 		case reflect.Int64, reflect.Uint64:
-			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "bigserial"
 			} else {

--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -31,17 +31,19 @@ func (sqlite3) DataTypeOf(field *StructField) string {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
 			sqlType = "integer"
 			if field.IsPrimaryKey {
-				sqlType += "primary key"
+				sqlType += " primary key"
 			}
 			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
-				sqlType += "autoincrement"
+				sqlType += " autoincrement"
 			}
 		case reflect.Int64, reflect.Uint64:
 			sqlType = "bigint"
 			if field.IsPrimaryKey {
-				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
-				sqlType = "integer primary key autoincrement"
-			} else {
+				if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
+					sqlType = "integer primary key autoincrement"
+				} else {
+					sqlType += "integer primary key"
+				}
 			}
 		case reflect.Float32, reflect.Float64:
 			sqlType = "real"

--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -29,18 +29,19 @@ func (sqlite3) DataTypeOf(field *StructField) string {
 		case reflect.Bool:
 			sqlType = "bool"
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
+			sqlType = "integer"
 			if field.IsPrimaryKey {
-				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
-				sqlType = "integer primary key autoincrement"
-			} else {
-				sqlType = "integer"
+				sqlType += "primary key"
+			}
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
+				sqlType += "autoincrement"
 			}
 		case reflect.Int64, reflect.Uint64:
+			sqlType = "bigint"
 			if field.IsPrimaryKey {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "integer primary key autoincrement"
 			} else {
-				sqlType = "bigint"
 			}
 		case reflect.Float32, reflect.Float64:
 			sqlType = "real"

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func TestStringPrimaryKey(t *testing.T) {
 	type UUIDStruct struct {
-		ID   string `gorm:"primary_key"`
+		ID   string `gorm:"primary_key;AUTO_INCREMENT"`
 		Name string
 	}
 	DB.AutoMigrate(&UUIDStruct{})

--- a/migration_test.go
+++ b/migration_test.go
@@ -130,7 +130,7 @@ func (i *Num) Scan(src interface{}) error {
 }
 
 type Animal struct {
-	Counter    uint64    `gorm:"primary_key:yes"`
+	Counter    uint64    `gorm:"primary_key:yes;AUTO_INCREMENT"`
 	Name       string    `sql:"DEFAULT:'galeone'"`
 	From       string    //test reserved sql keyword as field name
 	Age        time.Time `sql:"DEFAULT:current_timestamp"`

--- a/model.go
+++ b/model.go
@@ -7,7 +7,7 @@ import "time"
 //      gorm.Model
 //    }
 type Model struct {
-	ID        uint `gorm:"primary_key"`
+	ID        uint `gorm:"primary_key;AUTO_INCREMENT"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time `sql:"index"`

--- a/multi_primary_keys_test.go
+++ b/multi_primary_keys_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Blog struct {
-	ID         uint   `gorm:"primary_key"`
+	ID         uint   `gorm:"primary_key;AUTO_INCREMENT"`
 	Locale     string `gorm:"primary_key"`
 	Subject    string
 	Body       string
@@ -18,7 +18,7 @@ type Blog struct {
 }
 
 type Tag struct {
-	ID     uint   `gorm:"primary_key"`
+	ID     uint   `gorm:"primary_key;AUTO_INCREMENT"`
 	Locale string `gorm:"primary_key"`
 	Value  string
 	Blogs  []*Blog `gorm:"many2many:blogs_tags"`

--- a/preload_test.go
+++ b/preload_test.go
@@ -734,12 +734,12 @@ func TestManyToManyPreloadWithMultiPrimaryKeys(t *testing.T) {
 
 	type (
 		Level1 struct {
-			ID           uint   `gorm:"primary_key;"`
+			ID           uint   `gorm:"primary_key;AUTO_INCREMENT"`
 			LanguageCode string `gorm:"primary_key"`
 			Value        string
 		}
 		Level2 struct {
-			ID           uint   `gorm:"primary_key;"`
+			ID           uint   `gorm:"primary_key;AUTO_INCREMENT"`
 			LanguageCode string `gorm:"primary_key"`
 			Value        string
 			Level1s      []Level1 `gorm:"many2many:levels;"`


### PR DESCRIPTION
This change removes the forcing of the auto increment field for sqllite, postgres and mysql when using an int and a primary key. Instead the AUTO_INCREMENT tag can be used. I've also updated the default Model in order to maintain compatibility with expected and existing behavior.