### PR TITLE
Add Oracle support

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -34,8 +34,8 @@ type Dialect interface {
 	// HasColumn check has column or not
 	HasColumn(tableName string, columnName string) bool
 
-	// LimitAndOffsetSQL return generated SQL with Limit and Offset, as mssql has special case
-	LimitAndOffsetSQL(limit, offset int) string
+	// LimitAndOffsetSQL return generated SQL with Limit and Offset, as mssql and oracle has special case
+	LimitAndOffsetSQL(limit, offset int) (whereSQL, suffixSQL string)
 	// SelectFromDummyTable return select values, for most dbs, `SELECT values` just works, mysql needs `SELECT value FROM DUAL`
 	SelectFromDummyTable() string
 	// LastInsertIdReturningSuffix most dbs support LastInsertId, but postgres needs to use `RETURNING`

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -122,13 +122,13 @@ func (s commonDialect) currentDatabase() (name string) {
 	return
 }
 
-func (commonDialect) LimitAndOffsetSQL(limit, offset int) (sql string) {
+func (commonDialect) LimitAndOffsetSQL(limit, offset int) (whereSQL, suffixSQL string) {
 	if limit > 0 || offset > 0 {
 		if limit >= 0 {
-			sql += fmt.Sprintf(" LIMIT %d", limit)
+			suffixSQL += fmt.Sprintf(" LIMIT %d", limit)
 		}
 		if offset >= 0 {
-			sql += fmt.Sprintf(" OFFSET %d", offset)
+			suffixSQL += fmt.Sprintf(" OFFSET %d", offset)
 		}
 	}
 	return

--- a/dialect_oracle.go
+++ b/dialect_oracle.go
@@ -1,0 +1,120 @@
+package gorm
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+type oracle struct {
+	commonDialect
+}
+
+func init() {
+	RegisterDialect("ora", &oracle{})
+}
+
+func (oracle) GetName() string {
+	return "ora"
+}
+
+func (oracle) Quote(key string) string {
+	return fmt.Sprintf("\"%s\"", strings.ToUpper(key))
+}
+
+func (oracle) SelectFromDummyTable() string {
+	return "FROM dual"
+}
+
+func (oracle) BindVar(i int) string {
+	return fmt.Sprintf(":%d", i)
+}
+
+func (oracle) DataTypeOf(field *StructField) string {
+	var dataValue, sqlType, size, additionalType = ParseFieldStructForDialect(field)
+
+	if sqlType == "" {
+		switch dataValue.Kind() {
+		case reflect.Bool:
+			sqlType = "CHAR(1)"
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
+			sqlType = "INTEGER"
+		case reflect.Int64, reflect.Uint64:
+			sqlType = "NUMBER"
+		case reflect.Float32, reflect.Float64:
+			sqlType = "FLOAT"
+		case reflect.String:
+			if size > 0 && size < 255 {
+				sqlType = fmt.Sprintf("VARCHAR(%d)", size)
+			} else {
+				sqlType = "VARCHAR(255)"
+			}
+		case reflect.Struct:
+			if _, ok := dataValue.Interface().(time.Time); ok {
+				sqlType = "TIMESTAMP"
+			}
+		}
+	}
+
+	if sqlType == "" {
+		panic(fmt.Sprintf("invalid sql type %s (%s) for ora", dataValue.Type().Name(), dataValue.Kind().String()))
+	}
+
+	if strings.TrimSpace(additionalType) == "" {
+		return sqlType
+	}
+	return fmt.Sprintf("%v %v", sqlType, additionalType)
+}
+
+func (s oracle) HasIndex(tableName string, indexName string) bool {
+	var count int
+	s.db.QueryRow("SELECT COUNT(*) FROM USER_INDEXES WHERE TABLE_NAME = :1 AND INDEX_NAME = :2", strings.ToUpper(tableName), strings.ToUpper(indexName)).Scan(&count)
+	return count > 0
+}
+
+func (s oracle) HasForeignKey(tableName string, foreignKeyName string) bool {
+	var count int
+	s.db.QueryRow("SELECT COUNT(*) FROM USER_CONSTRAINTS WHERE CONSTRAINT_TYPE = 'R' AND TABLE_NAME = :1 AND CONSTRAINT_NAME = :2", strings.ToUpper(tableName), strings.ToUpper(foreignKeyName)).Scan(&count)
+	return count > 0
+}
+
+func (s oracle) HasTable(tableName string) bool {
+	var count int
+	s.db.QueryRow("SELECT COUNT(*) FROM USER_TABLES WHERE TABLE_NAME = :1", strings.ToUpper(tableName)).Scan(&count)
+	return count > 0
+}
+
+func (s oracle) HasColumn(tableName string, columnName string) bool {
+	var count int
+	s.db.QueryRow("SELECT COUNT(*) FROM USER_TAB_COLUMNS WHERE TABLE_NAME = :1 AND COLUMN_NAME = :2", strings.ToUpper(tableName), strings.ToUpper(columnName)).Scan(&count)
+	return count > 0
+}
+
+func (oracle) LimitAndOffsetSQL(limit, offset int) (whereSQL, suffixSQL string) {
+	if limit > 0 {
+		whereSQL += fmt.Sprintf("ROWNUM <= %d", limit)
+	}
+	return
+}
+
+func (s oracle) BuildForeignKeyName(tableName, field, dest string) string {
+	keyName := s.commonDialect.BuildForeignKeyName(tableName, field, dest)
+	if utf8.RuneCountInString(keyName) <= 30 {
+		return keyName
+	}
+	h := sha1.New()
+	h.Write([]byte(keyName))
+	bs := h.Sum(nil)
+
+	// sha1 is 40 digits, keep first 24 characters of destination
+	destRunes := []rune(regexp.MustCompile("(_*[^a-zA-Z]+_*|_+)").ReplaceAllString(dest, "_"))
+	result := fmt.Sprintf("%s%x", string(destRunes), bs)
+	if len(result) <= 30 {
+		return result
+	}
+	return result[:29]
+}

--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -127,16 +127,16 @@ func (s mssql) currentDatabase() (name string) {
 	return
 }
 
-func (mssql) LimitAndOffsetSQL(limit, offset int) (sql string) {
+func (mssql) LimitAndOffsetSQL(limit, offset int) (whereSQL, suffixSQL string) {
 	if limit > 0 || offset > 0 {
 		if offset < 0 {
 			offset = 0
 		}
 
-		sql += fmt.Sprintf(" OFFSET %d ROWS", offset)
+		suffixSQL += fmt.Sprintf(" OFFSET %d ROWS", offset)
 
 		if limit >= 0 {
-			sql += fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", limit)
+			suffixSQL += fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", limit)
 		}
 	}
 	return

--- a/dialects/ora/oracle.go
+++ b/dialects/ora/oracle.go
@@ -1,0 +1,3 @@
+package oracle
+
+import _ "gopkg.in/rana/ora.v3"

--- a/main.go
+++ b/main.go
@@ -561,7 +561,15 @@ func (s *DB) RemoveIndex(indexName string) *DB {
 
 // AddForeignKey Add foreign key to the given scope, e.g:
 //     db.Model(&User{}).AddForeignKey("city_id", "cities(id)", "RESTRICT", "RESTRICT")
-func (s *DB) AddForeignKey(field string, dest string, onDelete string, onUpdate string) *DB {
+func (s *DB) AddForeignKey(field string, dest string, options ...string) *DB {
+	var onDelete string
+	var onUpdate string
+	if len(options) >= 1 {
+		onDelete = options[0]
+	}
+	if len(options) >= 2 {
+		onUpdate = options[1]
+	}
 	scope := s.clone().NewScope(s.Value)
 	scope.addForeignKey(field, dest, onDelete, onUpdate)
 	return scope.db


### PR DESCRIPTION
Observations:

- [ ] I think we can't get it working right with sequences. I think we also can't return the inserted ID in the same query
- [ ] This warning is shown on creating an index: `no RowsAffected available after DDL statement`
- [x] ~~There's no `LIMIT 1` suffix for Oracle, we have to use `WHERE ROWNUM <= 1`, so the current dialect interface won't work for this.~~ I fixed this but only `LIMIT` work (via `ROWNUM`), `OFFSET` is ignored for compatibility with Oracle 11c