### PR TITLE
fix panic in AddForeignKey on mysql dialect

### DIFF
--- a/migration_test.go
+++ b/migration_test.go
@@ -49,6 +49,16 @@ type ReallyLongTableNameToTestMySQLNameLengthLimit struct {
 	Id int64
 }
 
+type ReallyLongThingThatReferencesShort struct {
+	Id      int64
+	ShortID int64
+	Short   Short
+}
+
+type Short struct {
+	Id int64
+}
+
 type CreditCard struct {
 	ID        int8
 	Number    string
@@ -241,7 +251,7 @@ func runMigration() {
 		DB.Exec(fmt.Sprintf("drop table %v;", table))
 	}
 
-	values := []interface{}{&ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Toy{}}
+	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Toy{}}
 	for _, value := range values {
 		DB.DropTable(value)
 	}


### PR DESCRIPTION
This fixes a panic introduced in #1029 and makes the character length calculation use utf8 runes, because that's what MySQL uses (["You can use multibyte characters without reducing the number of characters permitted for values stored in these columns."](http://dev.mysql.com/doc/refman/5.7/en/identifiers.html)).