### PR TITLE
Fixed an occurrence of a panic while preloading non existent fields.

### DIFF
--- a/callback_query_preload.go
+++ b/callback_query_preload.go
@@ -28,6 +28,10 @@ func preloadCallback(scope *Scope) {
 		for idx, preloadField := range preloadFields {
 			var currentPreloadConditions []interface{}
 
+			if currentScope == nil {
+				continue
+			}
+
 			// if not preloaded
 			if preloadKey := strings.Join(preloadFields[:idx+1], "."); !preloadedMap[preloadKey] {
 
@@ -67,7 +71,9 @@ func preloadCallback(scope *Scope) {
 			// preload next level
 			if idx < len(preloadFields)-1 {
 				currentScope = currentScope.getColumnAsScope(preloadField)
-				currentFields = currentScope.Fields()
+				if currentScope != nil {
+					currentFields = currentScope.Fields()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I have encountered a possible panic while preloading non existent fields (e.g. a foreign key can be NULL).

Check the unit tests. Uncomment my bugfix in `callback_query_preload.go` and run the tests to verify the bug. You will get a panic because `currentScope.getColumnAsScope` can possibly return nil pointer and you don not check for that case currently.