### PR TITLE
Revert "Use int64 for limit/offset values to ensure values > 32-bit int are addressable."

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -35,7 +35,7 @@ type Dialect interface {
 	HasColumn(tableName string, columnName string) bool
 
 	// LimitAndOffsetSQL return generated SQL with Limit and Offset, as mssql has special case
-	LimitAndOffsetSQL(limit, offset int64) string
+	LimitAndOffsetSQL(limit, offset int) string
 	// SelectFromDummyTable return select values, for most dbs, `SELECT values` just works, mysql needs `SELECT value FROM DUAL`
 	SelectFromDummyTable() string
 	// LastInsertIdReturningSuffix most dbs support LastInsertId, but postgres needs to use `RETURNING`

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -122,7 +122,7 @@ func (s commonDialect) currentDatabase() (name string) {
 	return
 }
 
-func (commonDialect) LimitAndOffsetSQL(limit, offset int64) (sql string) {
+func (commonDialect) LimitAndOffsetSQL(limit, offset int) (sql string) {
 	if limit > 0 || offset > 0 {
 		if limit >= 0 {
 			sql += fmt.Sprintf(" LIMIT %d", limit)

--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -127,7 +127,7 @@ func (s mssql) currentDatabase() (name string) {
 	return
 }
 
-func (mssql) LimitAndOffsetSQL(limit, offset int64) (sql string) {
+func (mssql) LimitAndOffsetSQL(limit, offset int) (sql string) {
 	if limit > 0 || offset > 0 {
 		if offset < 0 {
 			offset = 0

--- a/main.go
+++ b/main.go
@@ -156,12 +156,12 @@ func (s *DB) Not(query interface{}, args ...interface{}) *DB {
 }
 
 // Limit specify the number of records to be retrieved
-func (s *DB) Limit(limit int64) *DB {
+func (s *DB) Limit(limit int) *DB {
 	return s.clone().search.Limit(limit).db
 }
 
 // Offset specify the number of records to skip before starting to return the records
-func (s *DB) Offset(offset int64) *DB {
+func (s *DB) Offset(offset int) *DB {
 	return s.clone().search.Offset(offset).db
 }
 

--- a/search.go
+++ b/search.go
@@ -15,8 +15,8 @@ type search struct {
 	omits            []string
 	orders           []string
 	preload          []searchPreload
-	offset           int64
-	limit            int64
+	offset           int
+	limit            int
 	group            string
 	tableName        string
 	raw              bool
@@ -82,12 +82,12 @@ func (s *search) Omit(columns ...string) *search {
 	return s
 }
 
-func (s *search) Limit(limit int64) *search {
+func (s *search) Limit(limit int) *search {
 	s.limit = limit
 	return s
 }
 
-func (s *search) Offset(offset int64) *search {
+func (s *search) Offset(offset int) *search {
 	s.offset = offset
 	return s
 }


### PR DESCRIPTION
Reverts jinzhu/gorm#1064