### PR TITLE
Fix autoincrement

### DIFF
--- a/create_test.go
+++ b/create_test.go
@@ -58,6 +58,9 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateWithAutoIncrement(t *testing.T) {
+	if dialect := os.Getenv("GORM_DIALECT"); dialect != "postgres" {
+		t.Skip("Skipping this because only postgres properly support auto_increment on a non-primary_key column")
+	}
 	user1 := User{}
 	user2 := User{}
 

--- a/create_test.go
+++ b/create_test.go
@@ -57,6 +57,18 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreateWithAutoIncrement(t *testing.T) {
+	user1 := User{}
+	user2 := User{}
+
+	DB.Create(&user1)
+	DB.Create(&user2)
+
+	if user2.Sequence-user1.Sequence != 1 {
+		t.Errorf("Auto increment should apply on Sequence")
+	}
+}
+
 func TestCreateWithNoGORMPrimayKey(t *testing.T) {
 	if dialect := os.Getenv("GORM_DIALECT"); dialect == "mssql" {
 		t.Skip("Skipping this because MSSQL will return identity only if the table has an Id column")

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -30,6 +30,14 @@ func (mysql) Quote(key string) string {
 func (mysql) DataTypeOf(field *StructField) string {
 	var dataValue, sqlType, size, additionalType = ParseFieldStructForDialect(field)
 
+	// MySQL allows only one auto increment column per table, and it must
+	// be a KEY column.
+	if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
+		if _, ok = field.TagSettings["INDEX"]; !ok && !field.IsPrimaryKey {
+			delete(field.TagSettings, "AUTO_INCREMENT")
+		}
+	}
+
 	if sqlType == "" {
 		switch dataValue.Kind() {
 		case reflect.Bool:

--- a/migration_test.go
+++ b/migration_test.go
@@ -33,6 +33,7 @@ type User struct {
 	Company           Company
 	Role
 	PasswordHash      []byte
+	Sequence          uint                  `gorm:"AUTO_INCREMENT"`
 	IgnoreMe          int64                 `sql:"-"`
 	IgnoreStringSlice []string              `sql:"-"`
 	Ignored           struct{ Name string } `sql:"-"`

--- a/model_struct.go
+++ b/model_struct.go
@@ -175,6 +175,10 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 					field.HasDefaultValue = true
 				}
 
+				if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
+					field.HasDefaultValue = true
+				}
+
 				indirectType := fieldStruct.Type
 				for indirectType.Kind() == reflect.Ptr {
 					indirectType = indirectType.Elem()


### PR DESCRIPTION
In the current implementation, AUTO_INCREMENT on simple attributes does not work on postgres.
This PR fixes that.