### PR TITLE
Use validated interface{} for limit/offset values to ensure values greater than max 32-bit integer are addressable.

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -35,7 +35,7 @@ type Dialect interface {
 	HasColumn(tableName string, columnName string) bool
 
 	// LimitAndOffsetSQL return generated SQL with Limit and Offset, as mssql has special case
-	LimitAndOffsetSQL(limit, offset int) string
+	LimitAndOffsetSQL(limit, offset interface{}) string
 	// SelectFromDummyTable return select values, for most dbs, `SELECT values` just works, mysql needs `SELECT value FROM DUAL`
 	SelectFromDummyTable() string
 	// LastInsertIdReturningSuffix most dbs support LastInsertId, but postgres needs to use `RETURNING`

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -122,13 +123,15 @@ func (s commonDialect) currentDatabase() (name string) {
 	return
 }
 
-func (commonDialect) LimitAndOffsetSQL(limit, offset int) (sql string) {
-	if limit > 0 || offset > 0 {
-		if limit >= 0 {
-			sql += fmt.Sprintf(" LIMIT %d", limit)
+func (commonDialect) LimitAndOffsetSQL(limit, offset interface{}) (sql string) {
+	if limit != nil {
+		if parsedLimit, err := strconv.ParseInt(fmt.Sprint(limit), 0, 0); err == nil && parsedLimit > 0 {
+			sql += fmt.Sprintf(" LIMIT %d", parsedLimit)
 		}
-		if offset >= 0 {
-			sql += fmt.Sprintf(" OFFSET %d", offset)
+	}
+	if offset != nil {
+		if parsedOffset, err := strconv.ParseInt(fmt.Sprint(offset), 0, 0); err == nil && parsedOffset > 0 {
+			sql += fmt.Sprintf(" OFFSET %d", parsedOffset)
 		}
 	}
 	return

--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -127,16 +128,15 @@ func (s mssql) currentDatabase() (name string) {
 	return
 }
 
-func (mssql) LimitAndOffsetSQL(limit, offset int) (sql string) {
-	if limit > 0 || offset > 0 {
-		if offset < 0 {
-			offset = 0
+func (mssql) LimitAndOffsetSQL(limit, offset interface{}) (sql string) {
+	if limit != nil {
+		if parsedLimit, err := strconv.ParseInt(fmt.Sprint(limit), 0, 0); err == nil && parsedLimit > 0 {
+			sql += fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", parsedLimit)
 		}
-
-		sql += fmt.Sprintf(" OFFSET %d ROWS", offset)
-
-		if limit >= 0 {
-			sql += fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", limit)
+	}
+	if offset != nil {
+		if parsedOffset, err := strconv.ParseInt(fmt.Sprint(offset), 0, 0); err == nil && parsedOffset > 0 {
+			sql += fmt.Sprintf(" OFFSET %d ROWS", parsedOffset)
 		}
 	}
 	return

--- a/main.go
+++ b/main.go
@@ -156,12 +156,12 @@ func (s *DB) Not(query interface{}, args ...interface{}) *DB {
 }
 
 // Limit specify the number of records to be retrieved
-func (s *DB) Limit(limit int) *DB {
+func (s *DB) Limit(limit interface{}) *DB {
 	return s.clone().search.Limit(limit).db
 }
 
 // Offset specify the number of records to skip before starting to return the records
-func (s *DB) Offset(offset int) *DB {
+func (s *DB) Offset(offset interface{}) *DB {
 	return s.clone().search.Offset(offset).db
 }
 

--- a/scaner_test.go
+++ b/scaner_test.go
@@ -3,6 +3,7 @@ package gorm_test
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -51,6 +52,12 @@ func (l ExampleStringSlice) Value() (driver.Value, error) {
 }
 
 func (l *ExampleStringSlice) Scan(input interface{}) error {
+	switch input.(type) {
+	case string:
+		fmt.Printf("string: %+v\n", input.(string))
+	case []byte:
+		fmt.Printf("[]byte: %+v\n", string(input.([]byte)))
+	}
 	return json.Unmarshal(input.([]byte), l)
 }
 

--- a/search.go
+++ b/search.go
@@ -15,8 +15,8 @@ type search struct {
 	omits            []string
 	orders           []string
 	preload          []searchPreload
-	offset           int
-	limit            int
+	offset           interface{}
+	limit            interface{}
 	group            string
 	tableName        string
 	raw              bool
@@ -82,12 +82,12 @@ func (s *search) Omit(columns ...string) *search {
 	return s
 }
 
-func (s *search) Limit(limit int) *search {
+func (s *search) Limit(limit interface{}) *search {
 	s.limit = limit
 	return s
 }
 
-func (s *search) Offset(offset int) *search {
+func (s *search) Offset(offset interface{}) *search {
 	s.offset = offset
 	return s
 }


### PR DESCRIPTION
Accept and validate an `interface{}` for limit/offset values to ensure values greater than 2 billion (signed 32-bit max) are addressable via LIMIT X OFFSET Y.

Unit-test output for GORM_DIALECT=postgres:

    jay@gigawatt-io:~/go/src/github.com/jinzhu/gorm$ GORM_DIALECT=postgres go test ./...
    ok      github.com/jinzhu/gorm  3.174s
    ?       github.com/jinzhu/gorm/dialects/mssql   [no test files]
    ?       github.com/jinzhu/gorm/dialects/mysql   [no test files]
    ?       github.com/jinzhu/gorm/dialects/postgres    [no test files]
    ?       github.com/jinzhu/gorm/dialects/sqlite  [no test files]
    jay@gigawatt-io:~/go/src/github.com/jinzhu/gorm$ echo $?
    0

Details and context:

Prior to January 2016 the limit/offset values were interface{}. This regression in functionality (which makes it impossible to paginate an offset beyond approx. ~2 billion) was introduced with commit hash e159ca19:

    jay@gigawatt-io:~/go/src/github.com/jinzhu/gorm$ git diff e159ca19~1...e159ca19 main.go
    diff --git a/main.go b/main.go
    index a56f282..461329f 100644
    --- a/main.go
    +++ b/main.go
    @@ -146,12 +146,12 @@
    -func (s *DB) Limit(value interface{}) *DB {
    -       return s.clone().search.Limit(value).db
    +func (s *DB) Limit(limit int) *DB {
    +       return s.clone().search.Limit(limit).db
    }
    
    -func (s *DB) Offset(value interface{}) *DB {
    -       return s.clone().search.Offset(value).db
    +func (s *DB) Offset(offset int) *DB {
    +       return s.clone().search.Offset(offset).db
    }

Final note:

Previously submitted as https://github.com/jinzhu/gorm/pull/1064, this is being resubmitted with `interface{}`s instead of `int64`s at @jinzhu's request.