### PR TITLE
Id -> ID

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -967,7 +967,7 @@ func (scope *Scope) shouldSaveAssociations() bool {
 func (scope *Scope) related(value interface{}, foreignKeys ...string) *Scope {
 	toScope := scope.db.NewScope(value)
 
-	for _, foreignKey := range append(foreignKeys, toScope.typeName()+"Id", scope.typeName()+"Id") {
+	for _, foreignKey := range append(foreignKeys, toScope.typeName()+"ID", scope.typeName()+"ID") {
 		fromField, _ := scope.FieldByName(foreignKey)
 		toField, _ := toScope.FieldByName(foreignKey)
 


### PR DESCRIPTION
首先非常感谢您的该项目帮助我解决了很多问题，今天学习该框架时发现了一个问题 不知是否为BUG 

问题如下：
GORM Guide 的文档和 GO 官方推荐均为 形如: UserID 的样式 但 调用时发现 需要书写为 UserId 形式 导致调用
形如: Db.Model(&arrange).Related(&accProject) 这样的结构时会报出 invalid association [] 问题 😄 

解决方式为:
将代码中 Id 改为了 ID 

英文略差 请谅解 🙏