### PR TITLE
Fixed bug when preload duplicates has many related objects.

### DIFF
--- a/callback_query_preload.go
+++ b/callback_query_preload.go
@@ -186,6 +186,13 @@ func (scope *Scope) handleHasManyPreload(field *Field, conditions []interface{})
 		for j := 0; j < indirectScopeValue.Len(); j++ {
 			object := indirect(indirectScopeValue.Index(j))
 			objectRealValue := getValueFromFields(object, relation.AssociationForeignFieldNames)
+			if j > 0 {
+				prevObject := indirect(indirectScopeValue.Index(j - 1))
+				prevObjectRealValue := getValueFromFields(prevObject, relation.AssociationForeignFieldNames)
+				if toString(prevObjectRealValue) == toString(objectRealValue) {
+					continue
+				}
+			}
 			if results, ok := preloadMap[toString(objectRealValue)]; ok {
 				f := object.FieldByName(field.Name)
 				f.Set(reflect.Append(f, results...))

--- a/preload_test.go
+++ b/preload_test.go
@@ -1509,6 +1509,84 @@ func TestNilPointerSlice2(t *testing.T) {
 	}
 }
 
+func TestPrefixedPreloadDuplication(t *testing.T) {
+	type (
+		Level4 struct {
+			ID       uint
+			Level3ID uint
+		}
+		Level3 struct {
+			ID      uint
+			Level4s []*Level4
+		}
+		Level2 struct {
+			ID       uint
+			Level3ID sql.NullInt64 `sql:"index"`
+			Level3   *Level3
+		}
+		Level1 struct {
+			ID       uint
+			Level2ID sql.NullInt64 `sql:"index"`
+			Level2   *Level2
+		}
+	)
+
+	DB.DropTableIfExists(new(Level3))
+	DB.DropTableIfExists(new(Level4))
+	DB.DropTableIfExists(new(Level2))
+	DB.DropTableIfExists(new(Level1))
+
+	if err := DB.AutoMigrate(new(Level3), new(Level4), new(Level2), new(Level1)).Error; err != nil {
+		t.Error(err)
+	}
+
+	lvl := new(Level3)
+	if err := DB.Save(lvl).Error; err != nil {
+		t.Error(err)
+	}
+
+	sublvl1 := &Level4{Level3ID: lvl.ID}
+	if err := DB.Save(sublvl1).Error; err != nil {
+		t.Error(err)
+	}
+	sublvl2 := &Level4{Level3ID: lvl.ID}
+	if err := DB.Save(sublvl2).Error; err != nil {
+		t.Error(err)
+	}
+
+	lvl.Level4s = []*Level4{sublvl1, sublvl2}
+
+	want1 := Level1{
+		Level2: &Level2{
+			Level3: lvl,
+		},
+	}
+	if err := DB.Save(&want1).Error; err != nil {
+		t.Error(err)
+	}
+
+	want2 := Level1{
+		Level2: &Level2{
+			Level3: lvl,
+		},
+	}
+	if err := DB.Save(&want2).Error; err != nil {
+		t.Error(err)
+	}
+
+	want := []Level1{want1, want2}
+
+	var got []Level1
+	err := DB.Preload("Level2.Level3.Level4s").Find(&got).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %s; want %s", toJSONString(got), toJSONString(want))
+	}
+}
+
 func toJSONString(v interface{}) []byte {
 	r, _ := json.MarshalIndent(v, "", "  ")
 	return r


### PR DESCRIPTION
This PR fixes a bug with preloads of `has many` related objects would be duplicated many times when using `Find` method. Consider this example:

```
	type (
		Postcode struct {
			ID     uint
			AreaID uint
		}
		Area struct {
			ID         uint
			Postcodes []*Postcode
		}
		User struct {
			ID       uint
		}
		UserArea struct {
			ID     uint
			UserID uint
			User   *User
			AreaID uint
			Area   *Area
		}
	)
```

In the structure above, we have multiple areas in our database such as `London`, `Paris`. Each area has a list of postcodes assigned to it, e.g. `EC1`, `EC2`.

We can then create a user area objects related to specific users. For example, a db structure like above could be used to store data about users wanting to buy / sell properties in different areas.

Now the bug is, if we create an area for `London` and assign two postcodes to it - `EC1`, `EC2` and since each user is looking for a house in the same area, we would create a user area object for both users.

When we fetch the users from the db and use `Preload("Area.Postcodes")`, each object would contain duplicate entries for postcodes, e.g. both users would have `["EC1", "EC2", "EC1", "EC2"]` even though that's clearly incorrect.

See the unit test I wrote to prove this bug.

You can run tests without the change in `callback_query_preload.go` to see it fail.

The change I made in `callback_query_preload.go` fixes this bug.

Please review and merge if happy :)

Also if you have a more elegant way to fix this bug, do it other way. I couldn't figure out a cleaner way to correct this behaviour.

@jinzhu please have a look