### PR TITLE
Add db.Close() examples to documentation

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -52,6 +52,7 @@ func main() {
   if err != nil {
     panic("failed to connect database")
   }
+  defer db.Close()
 
   // Migrate the schema
   db.AutoMigrate(&Product{})

--- a/documents/database.md
+++ b/documents/database.md
@@ -31,6 +31,7 @@ import (
 
 func main() {
   db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
+  defer db.Close()
 }
 ```
 
@@ -44,6 +45,7 @@ import (
 
 func main() {
   db, err := gorm.Open("postgres", "host=myhost user=gorm dbname=gorm sslmode=disable password=mypassword")
+  defer db.Close()
 }
 ```
 
@@ -57,6 +59,7 @@ import (
 
 func main() {
   db, err := gorm.Open("sqlite3", "/tmp/gorm.db")
+  defer db.Close()
 }
 ```
 


### PR DESCRIPTION
Adds `defer db.Close()` to README.md's "getting started" example as well as the Database Connections section.

This makes it clear that `db.Close()` is important after a `db, err := gorm.Open(...)`.

Looking at [sourcegraph.com](https://sourcegraph.com), there are [219 repositories](https://sourcegraph.com/github.com/jinzhu/gorm/-/info/GoPackage/github.com/jinzhu/gorm/-/Open) referencing `gorm.Open(...)` and only [38 repositories](https://sourcegraph.com/github.com/jinzhu/gorm/-/info/GoPackage/github.com/jinzhu/gorm/-/DB/Close) referencing `gorm.Close()`. That indicates people could benefit from the example.

---

Note: I am purposely omitting a `nil` check for `db` in the example but it can be added to be more verbose and safe when coding. Something like:

```
db, err := gorm.Open(...)
if err != nil {
  panic(...)
}
if db != nil {
  defer db.Close()
}
```
