### PR TITLE
Fix typos

### DIFF
--- a/documents/associations.md
+++ b/documents/associations.md
@@ -136,7 +136,7 @@ type Profile struct {
 
 type User struct {
   gorm.Model
-  Profile []Profiles `gorm:"ForeignKey:UserRefer"`
+  Profiles []Profile `gorm:"ForeignKey:UserRefer"`
 }
 ```
 
@@ -152,7 +152,7 @@ type Profile struct {
 type User struct {
   gorm.Model
   Refer   string
-  Profile []Profiles `gorm:"ForeignKey:UserID;AssociationForeignKey:Refer"`
+  Profiles []Profile `gorm:"ForeignKey:UserID;AssociationForeignKey:Refer"`
 }
 ```
 


### PR DESCRIPTION
Hey!

Seems it's a typo
Field must be called like `Profiles` with type of []Profile

Thanks