### PR TITLE
Fix duplicate updates when saving assocation

### DIFF
--- a/association.go
+++ b/association.go
@@ -353,9 +353,7 @@ func (association *Association) saveAssociations(values ...interface{}) *Associa
 		if indirectReflectValue.Kind() == reflect.Struct {
 			saveAssociation(reflectValue)
 		} else if indirectReflectValue.Kind() == reflect.Slice {
-			for i := 0; i < indirectReflectValue.Len(); i++ {
-				saveAssociation(indirectReflectValue.Index(i))
-			}
+			saveAssociation(indirectReflectValue)
 		} else {
 			association.setErr(errors.New("invalid value type"))
 		}


### PR DESCRIPTION
When using Replace to update a has-many association, items in the replace array are being updated more than once.  This happens because on each run through the loop of values, it saves all previous values in the array.  As the number of elements being set grows, it becomes quite slow.

It appears that the saveAssociation method is already setup to handle arrays correctly, so there is no need to loop here.  Removing the loop resolves the issue.

An example from the docs:

`
db.Model(&user).Association("Languages").Replace([]Language{languageZH, languageEN})
`

The above could would generate:

UPDATE for languageZH
UPDATE for languageZH (duplicated)
UPDATE for languageEN
DELETE to clean up old languages

adding a third language, would add 3 additional UPDATE statements (another for languageZH, and languageEN, plus one for the additional language) 