### PR TITLE
Allow disabling of automatic Ping

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func Open(dialect string, args ...interface{}) (*DB, error) {
 	} else {
 		var source string
 		var dbSQL sqlCommon
+		dontPing := false
 
 		switch value := args[0].(type) {
 		case string:
@@ -61,6 +62,12 @@ func Open(dialect string, args ...interface{}) (*DB, error) {
 		case sqlCommon:
 			source = reflect.Indirect(reflect.ValueOf(value)).FieldByName("dsn").String()
 			dbSQL = value
+			if len(args) == 2 {
+				aBool, correct := args[1].(bool)
+				if correct == true {
+					dontPing = aBool
+				}
+			}
 		}
 
 		db = DB{
@@ -73,7 +80,7 @@ func Open(dialect string, args ...interface{}) (*DB, error) {
 		}
 		db.parent = &db
 
-		if err == nil {
+		if err == nil && !dontPing {
 			err = db.DB().Ping() // Send a ping to make sure the database connection is alive.
 		}
 	}


### PR DESCRIPTION
The `gorm.Open(...)` function allows feeding in a `*sql.DB` object instead of allowing gorm to create the object itself.

In many cases, the reason why we do it is because we already have a valid sql.DB object that we have used elsewhere. We know the connection is valid already. We don't need to **waste a round trip** by using `.Ping()` to test if it is valid.

This pull request allows us to `opt-out` of gorm automatically calling Ping.
The default is the current behaviour. It is also backwards-compatible so it should not affect prior code.



