### PR TITLE
Find: order by primary key by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -253,7 +253,8 @@ func (s *DB) Last(out interface{}, where ...interface{}) *DB {
 
 // Find find records that match given conditions
 func (s *DB) Find(out interface{}, where ...interface{}) *DB {
-	return s.clone().NewScope(out).inlineCondition(where...).callCallbacks(s.parent.callbacks.queries).db
+	newScope := s.clone().NewScope(out)
+	return newScope.Set("gorm:order_by_primary_key", "ASC").inlineCondition(where...).callCallbacks(s.parent.callbacks.queries).db
 }
 
 // Scan scan value to a struct


### PR DESCRIPTION
Hi there !

There is currently no default order for preloaded tables when Find() is used.
I have added gorm:order_by_primary_key to scope, the same way it's added in First().