### PR TITLE
Add primary key check before delete

### DIFF
--- a/callback_delete.go
+++ b/callback_delete.go
@@ -20,6 +20,10 @@ func beforeDeleteCallback(scope *Scope) {
 
 // deleteCallback used to delete data from database or set deleted_at to current time (when using with soft delete)
 func deleteCallback(scope *Scope) {
+	if scope.PrimaryKeyZero() {
+		scope.db.AddError(ErrNonSpecificDelete)
+	}
+
 	if !scope.HasError() {
 		var extraOption string
 		if str, ok := scope.Get("gorm:delete_option"); ok {

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,8 @@ import (
 )
 
 var (
+	// ErrNonSpecificDelete no primary key specified for delete, happens when you try to `Delete` a record without a primary key set
+	ErrNonSpecificDelete = errors.New("no primary key specified for delete")
 	// ErrRecordNotFound record not found error, happens when haven't find any matched data when looking up with a struct
 	ErrRecordNotFound = errors.New("record not found")
 	// ErrInvalidSQL invalid SQL error, happens when you passed invalid SQL


### PR DESCRIPTION
Added primary key validation before deleting a record to ensure all records aren't deleted if a primary key is not set when calling `db.Delete(value)`. That behaviour should be reserved for `db.DropTable()` or have it's own function.

Unfortunately I haven't been able to add a test as running `go test` returned error:

```
./query_test.go:311: cannot use gorm.Expr("name = ? DESC", "OrderPluckUser2") (type *gorm.expr) as type string in argument to scopedb.Order
FAIL	github.com/danhardman/gorm [build failed]
```

Shouldn't have to be fiddling around with other code to get this working! 