### PR TITLE
fix goroutine leak while calling db.Ping() error

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,9 @@ func Open(dialect string, args ...interface{}) (*DB, error) {
 
 		if err == nil {
 			err = db.DB().Ping() // Send a ping to make sure the database connection is alive.
+			if err != nil {
+				db.DB().Close()
+			}
 		}
 	}
 


### PR DESCRIPTION
if db.Ping() is error,  we should close db and return error. fix for #1189 