### PR TITLE
Include 'LastInsertId' for exec queries.

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ type DB struct {
 	Value             interface{}
 	Error             error
 	RowsAffected      int64
+	LastInsertId      int64
 	callbacks         *Callback
 	db                sqlCommon
 	parent            *DB

--- a/scope.go
+++ b/scope.go
@@ -348,6 +348,9 @@ func (scope *Scope) Exec() *Scope {
 			if count, err := result.RowsAffected(); scope.Err(err) == nil {
 				scope.db.RowsAffected = count
 			}
+			if lastInsertId, err := result.LastInsertId(); scope.Err(err) == nil {
+				scope.db.LastInsertId = lastInsertId
+			}
 		}
 	}
 	return scope


### PR DESCRIPTION
Same way that `RowsAffected` is incorporated into the result include `LastInsertId` too.