### PR TITLE
If no arguments, return error at once

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -754,6 +754,16 @@ func TestDdlErrors(t *testing.T) {
 	}
 }
 
+func TestOpenWithOneParameter(t *testing.T) {
+	db, err := gorm.Open("dialect")
+	if db != nil {
+		t.Error("Open with one parameter returned non nil for db")
+	}
+	if err == nil {
+		t.Error("Open with one parameter returned err as nil")
+	}
+}
+
 func BenchmarkGorm(b *testing.B) {
 	b.N = 2000
 	for x := 0; x < b.N; x++ {


### PR DESCRIPTION
This is the scenario:

1. Caller side calls the Open without argument
2. Caller side calls the Close afterwards when `err != nil` - [this will panic](https://github.com/almighty/almighty-core/pull/344#discussion_r82363818)

- [x] Write test case