### PR TITLE
Added redshift support & added Dialect.SupportLastInsertID interface method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 documents
 _book
+.DS_Store

--- a/dialect.go
+++ b/dialect.go
@@ -40,6 +40,7 @@ type Dialect interface {
 	SelectFromDummyTable() string
 	// LastInsertIdReturningSuffix most dbs support LastInsertId, but postgres needs to use `RETURNING`
 	LastInsertIDReturningSuffix(tableName, columnName string) string
+	SupportLastInsertID() bool
 
 	// BuildForeignKeyName returns a foreign key name for the given table, field and reference
 	BuildForeignKeyName(tableName, field, dest string) string

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -145,6 +145,10 @@ func (commonDialect) LastInsertIDReturningSuffix(tableName, columnName string) s
 	return ""
 }
 
+func (commonDialect) SupportLastInsertID() bool {
+	return true
+}
+
 func (DefaultForeignKeyNamer) BuildForeignKeyName(tableName, field, dest string) string {
 	keyName := fmt.Sprintf("%s_%s_%s_foreign", tableName, field, dest)
 	keyName = regexp.MustCompile("(_*[^a-zA-Z]+_*|_+)").ReplaceAllString(keyName, "_")

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -144,3 +144,7 @@ func (s mysql) BuildForeignKeyName(tableName, field, dest string) string {
 
 	return fmt.Sprintf("%s%x", string(destRunes), bs)
 }
+
+func (mysql) SupportLastInsertID() bool {
+	return true
+}

--- a/dialect_redshift.go
+++ b/dialect_redshift.go
@@ -35,25 +35,14 @@ func (redshift) DataTypeOf(field *StructField) string {
 		case reflect.Float64:
 			sqlType = "float8"
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
-			if field.IsPrimaryKey {
-				delete(field.TagSettings, "AUTO_INCREMENT")
-				delete(field.TagSettings, "IDENTITY(1, 1)")
-				sqlType = "integer IDENTITY(1, 1)"
-			} else if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
-				delete(field.TagSettings, "AUTO_INCREMENT")
-				delete(field.TagSettings, "IDENTITY(1, 1)")
-				sqlType = "integer IDENTITY(1, 1)"
-			} else if _, ok := field.TagSettings["IDENTITY(1, 1)"]; ok {
-				delete(field.TagSettings, "AUTO_INCREMENT")
-				delete(field.TagSettings, "IDENTITY(1, 1)")
-				sqlType = "integer IDENTITY(1, 1)"
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; field.IsPrimaryKey || ok {
+				sqlType = "integer DISTKEY IDENTITY(1, 1)"
 			} else {
 				sqlType = "integer"
 			}
 		case reflect.Int64, reflect.Uintptr, reflect.Uint64:
-			if _, ok := field.TagSettings["IDENTITY(1, 1)"]; ok || field.IsPrimaryKey {
-				field.TagSettings["IDENTITY(1, 1)"] = "IDENTITY(1, 1)"
-				sqlType = "bigint"
+			if _, ok := field.TagSettings["AUTO_INCREMENT"]; field.IsPrimaryKey || ok {
+				sqlType = "bigint DISTKEY IDENTITY(1, 1)"
 			} else {
 				sqlType = "bigint"
 			}

--- a/dialect_redshift.go
+++ b/dialect_redshift.go
@@ -1,0 +1,123 @@
+package gorm
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+type redshift struct {
+	commonDialect
+}
+
+func init() {
+	RegisterDialect("redshift", &redshift{})
+}
+
+func (redshift) GetName() string {
+	return "redshift"
+}
+
+func (redshift) BindVar(i int) string {
+	return fmt.Sprintf("$%v", i)
+}
+
+func (redshift) DataTypeOf(field *StructField) string {
+	var dataValue, sqlType, size, additionalType = ParseFieldStructForDialect(field)
+
+	if sqlType == "" {
+		switch dataValue.Kind() {
+		case reflect.Bool:
+			sqlType = "boolean"
+		case reflect.Float32:
+			sqlType = "float4"
+		case reflect.Float64:
+			sqlType = "float8"
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+			if field.IsPrimaryKey {
+				delete(field.TagSettings, "AUTO_INCREMENT")
+				delete(field.TagSettings, "IDENTITY(1, 1)")
+				sqlType = "integer IDENTITY(1, 1)"
+			} else if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok {
+				delete(field.TagSettings, "AUTO_INCREMENT")
+				delete(field.TagSettings, "IDENTITY(1, 1)")
+				sqlType = "integer IDENTITY(1, 1)"
+			} else if _, ok := field.TagSettings["IDENTITY(1, 1)"]; ok {
+				delete(field.TagSettings, "AUTO_INCREMENT")
+				delete(field.TagSettings, "IDENTITY(1, 1)")
+				sqlType = "integer IDENTITY(1, 1)"
+			} else {
+				sqlType = "integer"
+			}
+		case reflect.Int64, reflect.Uintptr, reflect.Uint64:
+			if _, ok := field.TagSettings["IDENTITY(1, 1)"]; ok || field.IsPrimaryKey {
+				field.TagSettings["IDENTITY(1, 1)"] = "IDENTITY(1, 1)"
+				sqlType = "bigint"
+			} else {
+				sqlType = "bigint"
+			}
+		case reflect.String:
+			if _, ok := field.TagSettings["SIZE"]; !ok {
+				size = 0 // if SIZE haven't been set, use `text` as the default type, as there are no performance different
+			}
+			if size > 0 && size < 65532 {
+				sqlType = fmt.Sprintf("varchar(%d)", size)
+			} else {
+				sqlType = "text"
+			}
+		case reflect.Struct:
+			if _, ok := dataValue.Interface().(time.Time); ok {
+				sqlType = "timestamp with time zone"
+			}
+		default:
+			sqlType = ""
+		}
+	}
+
+	if sqlType == "" {
+		panic(fmt.Sprintf("invalid sql type %s (%s) for redshift", dataValue.Type().Name(), dataValue.Kind().String()))
+	}
+
+	if strings.TrimSpace(additionalType) == "" {
+		return sqlType
+	}
+	return fmt.Sprintf("%v %v", sqlType, additionalType)
+}
+
+func (s redshift) HasIndex(tableName string, indexName string) bool {
+	var count int
+	s.db.QueryRow("SELECT count(*) FROM pg_indexes WHERE tablename = $1 AND indexname = $2", tableName, indexName).Scan(&count)
+	return count > 0
+}
+
+func (s redshift) HasForeignKey(tableName string, foreignKeyName string) bool {
+	var count int
+	s.db.QueryRow("SELECT count(con.conname) FROM pg_constraint con WHERE $1::regclass::oid = con.conrelid AND con.conname = $2 AND con.contype='f'", tableName, foreignKeyName).Scan(&count)
+	return count > 0
+}
+
+func (s redshift) HasTable(tableName string) bool {
+	var count int
+	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = $1 AND table_type = 'BASE TABLE'", tableName).Scan(&count)
+	return count > 0
+}
+
+func (s redshift) HasColumn(tableName string, columnName string) bool {
+	var count int
+	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.columns WHERE table_name = $1 AND column_name = $2", tableName, columnName).Scan(&count)
+	return count > 0
+}
+
+func (s redshift) CurrentDatabase() (name string) {
+	s.db.QueryRow("SELECT CURRENT_DATABASE()").Scan(&name)
+	return
+}
+
+func (s redshift) LastInsertIDReturningSuffix(tableName, key string) string {
+	return ""
+}
+
+func (redshift) SupportLastInsertID() bool {
+	return false
+}

--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -106,3 +106,7 @@ func (s sqlite3) CurrentDatabase() (name string) {
 	}
 	return
 }
+
+func (sqlite3) SupportLastInsertID() bool {
+	return true
+}

--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -149,3 +149,7 @@ func (mssql) SelectFromDummyTable() string {
 func (mssql) LastInsertIDReturningSuffix(tableName, columnName string) string {
 	return ""
 }
+
+func (mssql) SupportLastInsertID() bool {
+	return true
+}

--- a/dialects/redshift/redshift.go
+++ b/dialects/redshift/redshift.go
@@ -1,0 +1,7 @@
+package redshift
+
+import (
+	_ "database/sql"
+	_ "database/sql/driver"
+	_ "github.com/lib/pq"
+)


### PR DESCRIPTION
### What
- Added a new "redshift" dialect
- Added interface method `Dialect.SupportLastInsertID`, redshift does not support `LastInsertId`
- Updated create_callback to check if the dialect supports LastInsertId: `scope.Dialect().SupportLastInsertID()`
### Why
- Redshift is very useful large scale data storage, but the create table syntax is not compatible with Postgresql
- Only a subset of data types are supported
- Redshift doesn't support _LastInsertId_ so we need to check for that when inserting new records.
### Example usage

``` go
package main

import (
    "os"
    "fmt"
    "github.com/jinzhu/gorm"
    _ "github.com/jinzhu/gorm/dialects/redshift"
)


type Product struct {
    ID uint `gorm:"DISTKEY IDENTITY(1, 1)"`
    Code string
    Price uint
}

func main() {
    // Get the database connection from the environment
    // Ex: 
    //   db_connection_string := "postgres://root:password@products.crtfrkqszbch.us-east-1.redshift.amazonaws.com:5439/products?sslmode=verify-ca&sslrootcert=./redshift-ssl-ca-cert.pem"
    // 
    // The redshift PEM is stored here:  https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html#connect-using-ssl
    // 
    db_connection_string := os.Getenv("DB_CONNECTION")
    db, err := gorm.Open("redshift", "postgres", db_connection_string)
    if err != nil {
        panic("failed to connect database: " + db_connection_string + "\n" + err.Error())
    }
    defer db.Close()
    // db.LogMode(true)

    db.DropTable(&Product{})

    // Migrate the schema
    db.AutoMigrate(&Product{})

    // Create
    db.Create(&Product{Code: "L1212", Price: 1000})

    // Read
    var product Product
    db.First(&product, 1) // find product with id 1
    db.First(&product, "code = ?", "L1212") // find product with code l1212

    // Update - update product's price to 2000
    db.Model(&product).Update("Price", 2000)

    // Delete - delete product
    db.Delete(&product)
}
```
