### PR TITLE
Update associations.md

### DIFF
--- a/documents/associations.md
+++ b/documents/associations.md
@@ -170,7 +170,7 @@ type Language struct {
 	Name string
 }
 
-db.Model(&user).Related(&languages)
+db.Model(&user).Related(&languages, "Languages")
 //// SELECT * FROM "languages" INNER JOIN "user_languages" ON "user_languages"."language_id" = "languages"."id" WHERE "user_languages"."user_id" = 111
 ```
 


### PR DESCRIPTION
Many to many association
should use
```
db.Model(&user).Related(&languages, "Languages") 
```
instead of
```
db.Model(&user).Related(&languages)
```
http://stackoverflow.com/questions/34667199/gorm-many-to-many-select-gives-invalid-association-error