### PR TITLE
fix a bug that gorm:column not use.

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -533,7 +533,14 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 			if value, ok := field.TagSettings["COLUMN"]; ok {
 				field.DBName = value
 			} else {
-				field.DBName = ToDBName(fieldStruct.Name)
+
+				tag := field.Tag.Get("gorm")
+
+				if len(tag) > 0 && strings.HasPrefix(tag, "cloumn:") {
+					field.DBName = strings.Replace(tag, "cloumn:", "", -1)
+				} else {
+					field.DBName = ToDBName(fieldStruct.Name)
+				}
 			}
 
 			modelStruct.StructFields = append(modelStruct.StructFields, field)


### PR DESCRIPTION
My struct like this:

type BatchRecord struct {
	Id      int64      `json:"id"      gorm:"primary_key"`   
	Status  int        `json:"status"  gorm:"column:status"` 
	Message string     `json:"message" gorm:"column:message"` 
	AppKey  string     `json:"appKey"  gorm:"cloumn:appKey"`
	AppId   int64      `json:"appId"   gorm:"column:appId"`
	Created time.Time  `json:"created" gorm:"cloumn:created"`
	Updated time.Time  `json:"updated" gorm:"cloumn:updated"`
}

the field.DBName output wrong like this:

column ==> id
column ==> status
column ==> message
column ==> app_key
column ==> appId
column ==> created
column ==> updated

i think it should be:

column ==> id
column ==> status
column ==> message
column ==> appKey
column ==> appId
column ==> created
column ==> updated
