### PR TITLE
Compile regexp ahead of time

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -26,6 +26,9 @@ var NowFunc = func() time.Time {
 var commonInitialisms = []string{"API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "LHS", "QPS", "RAM", "RHS", "RPC", "SLA", "SMTP", "SSH", "TLS", "TTL", "UI", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XSRF", "XSS"}
 var commonInitialismsReplacer *strings.Replacer
 
+var goSrcRegexp = regexp.MustCompile(`jinzhu/gorm/.*.go`)
+var goTestRegexp = regexp.MustCompile(`jinzhu/gorm/.*test.go`)
+
 func init() {
 	var commonInitialismsForReplacer []string
 	for _, initialism := range commonInitialisms {
@@ -171,7 +174,7 @@ func toQueryValues(values [][]interface{}) (results []interface{}) {
 func fileWithLineNum() string {
 	for i := 2; i < 15; i++ {
 		_, file, line, ok := runtime.Caller(i)
-		if ok && (!regexp.MustCompile(`jinzhu/gorm/.*.go`).MatchString(file) || regexp.MustCompile(`jinzhu/gorm/.*test.go`).MatchString(file)) {
+		if ok && (!goSrcRegexp.MatchString(file) || goTestRegexp.MatchString(file)) {
 			return fmt.Sprintf("%v:%v", file, line)
 		}
 	}


### PR DESCRIPTION
@jinzhu Please take a look.

This change pulls regexp compilation out of some (potentially) hot functions to be done ahead of time.

This leads to a small performance increase with little cost.

I can wrangle up some benchmarks if you really want proof but it should be fairly self-evident, this work will now only be done one time vs. several times. 

Signed-off-by: Xavier Sandal <sandalwing@sandalwing.com>