### PR TITLE
Fix *Scope.buildNotCondition

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -593,8 +593,9 @@ func (scope *Scope) buildNotCondition(clause map[string]interface{}) (str string
 		if reflect.ValueOf(value).Len() > 0 {
 			str = fmt.Sprintf("(%v.%v NOT IN (?))", scope.QuotedTableName(), scope.Quote(primaryKey))
 			clause["args"] = []interface{}{value}
+		} else {
+			return ""
 		}
-		return ""
 	case map[string]interface{}:
 		var sqls []string
 		for key, value := range value {


### PR DESCRIPTION
this fixes the logic of handling empty slice of int family in a query i.e something linke `[]int64{}`

This code snipped doesn't look like it was intended to be this way

```
	if reflect.ValueOf(value).Len() > 0 {
			str = fmt.Sprintf("(%v.%v NOT IN (?))", scope.QuotedTableName(), scope.Quote(primaryKey))
			clause["args"] = []interface{}{value}
		}
		return ""
```

The `return ""` is always guaranteed to be executed regardless of whether the length of value is greater than 0. I believe the intended behavior is to return  `""` when the length of value is zero.