### PR TITLE
Enable fractional seconds in Time column for Mysql

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -80,10 +81,18 @@ func (mysql) DataTypeOf(field *StructField) string {
 			}
 		case reflect.Struct:
 			if _, ok := dataValue.Interface().(time.Time); ok {
-				if _, ok := field.TagSettings["NOT NULL"]; ok {
-					sqlType = "timestamp"
+				if num, ok := field.TagSettings["FRAC"]; ok {
+					frac, err := strconv.Atoi(num)
+					if err != nil || frac < 0 {
+						frac = 0
+					}
+					if frac > 6 {
+						frac = 6
+					}
+
+					sqlType = fmt.Sprintf("timestamp(%d)", frac)
 				} else {
-					sqlType = "timestamp NULL"
+					sqlType = "timestamp"
 				}
 			}
 		default:


### PR DESCRIPTION
Mysql (5.6.4 and up) supports up to 6 digits fractional seconds in
Time values. This patch adds "frac" field annotation to support it.

http://dev.mysql.com/doc/refman/5.7/en/fractional-seconds.html

Sample usage:
Foo { ts time.Time `sql:"frac:3"` }