### PR TITLE
Fix "Unsupported destination" error when value is pointer of pointer

### DIFF
--- a/callback_query.go
+++ b/callback_query.go
@@ -33,6 +33,10 @@ func queryCallback(scope *Scope) {
 		results = reflect.Indirect(reflect.ValueOf(value))
 	}
 
+	for results.Kind() == reflect.Ptr {
+		results = results.Elem()
+	}
+
 	if kind := results.Kind(); kind == reflect.Slice {
 		isSlice = true
 		resultType = results.Type().Elem()


### PR DESCRIPTION
Happens when you give `**User` instead of `*User` to `db.Save`, `db.Create`.