### PR TITLE
Add support for excluding a field from an index in the model struct.

### DIFF
--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -27,7 +27,7 @@ func (s *sqlite3) DataTypeOf(field *StructField) string {
 	if sqlType == "" {
 		switch dataValue.Kind() {
 		case reflect.Bool:
-			sqlType = "bool"
+			sqlType = "numeric"
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
 			if field.IsPrimaryKey {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"


### PR DESCRIPTION
Hi,

When using soft deletes, one may want to allow a new record to be created with the same values as an existing unique index. This is problematic with the default implementation of `DeletedAt` that Gorm supports (see, for example, #1121), but is also easily avoidable on most DBMSes. In fact it's trivial to create this type of unique index manually with Gorm, but we wanted to be able to embed it into our structs too.

Internally, we came up with the solution of adding the ability to exclude the default value of a field from an index. In other words, given the following struct (notice the `!` before the index name in the `DeletedAt` tag):

```go
struct User {
  ID        uint64     `gorm:"primary_key"`
  Email     string     `gorm:"unique_index:uix_users_email"`
  DeletedAt *time.Time `gorm:"unique_index:!uix_users_email"`
}
```

We generate the following SQL (for PostgreSQL, for example):
```sql
CREATE UNIQUE INDEX uix_users_email ON "users"("email") WHERE ("deleted_at" IS NULL)
```

I'm not totally happy with the code here (especially the way the `WHERE` clause is built; databases don't seem to support parameterized queries when constructing indexes) nor the specific syntax for the struct field tag, but I wanted to get your feedback on the general approach and hopefully eventually land something that provides this functionality in Gorm.

I'm happy to write some docs for this as well once it lands.

Thanks!