### PR TITLE
Fix issue with mssql NEXT option.

### DIFF
--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -129,14 +129,18 @@ func (s mssql) CurrentDatabase() (name string) {
 }
 
 func (mssql) LimitAndOffsetSQL(limit, offset interface{}) (sql string) {
-	if limit != nil {
-		if parsedLimit, err := strconv.ParseInt(fmt.Sprint(limit), 0, 0); err == nil && parsedLimit > 0 {
-			sql += fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", parsedLimit)
-		}
-	}
 	if offset != nil {
 		if parsedOffset, err := strconv.ParseInt(fmt.Sprint(offset), 0, 0); err == nil && parsedOffset > 0 {
 			sql += fmt.Sprintf(" OFFSET %d ROWS", parsedOffset)
+		}
+	}
+	if limit != nil {
+		if parsedLimit, err := strconv.ParseInt(fmt.Sprint(limit), 0, 0); err == nil && parsedLimit > 0 {
+			if sql == "" {
+				// add default zero offset
+				sql += " OFFSET 0 ROWS"
+			}
+			sql += fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", parsedLimit)
 		}
 	}
 	return


### PR DESCRIPTION
Fixes #1205

Simple applying @dipbhi's fix from https://github.com/jinzhu/gorm/issues/1205#issuecomment-260104461

Solves my issues with `(mssql: Invalid usage of the option NEXT in the FETCH statement.)`