### PR TITLE
Remove 'sqlite' dialect registration

### DIFF
--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -12,7 +12,6 @@ type sqlite3 struct {
 }
 
 func init() {
-	RegisterDialect("sqlite", &sqlite3{})
 	RegisterDialect("sqlite3", &sqlite3{})
 }
 


### PR DESCRIPTION
Removing this line as there's no significant need for it. In fact, it was confusing me as a developer using the API.

Even though SQLite is registered with the `sqlite` dialect through GORM, when it's passed to `mattn/go-sqlite3`, it will throw an error.

Using the following code:

```go
gorm, err := gorm.Open("sqlite", "db.sqlite")
```

will result in the following error:

```go
sql: unknown driver "sqlite" (forgotten import?)
```

Given that you must use `sqlite3` to use SQLite, this line is unnecessary.