### PR TITLE
Remove SET_IDENTITY_INSERT for transactions in MS SQL

### DIFF
--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -12,14 +12,7 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-func setIdentityInsert(scope *gorm.Scope) {
-	if scope.Dialect().GetName() == "mssql" {
-		scope.NewDB().Exec(fmt.Sprintf("SET IDENTITY_INSERT %v ON", scope.TableName()))
-	}
-}
-
 func init() {
-	gorm.DefaultCallback.Create().After("gorm:begin_transaction").Register("mssql:set_identity_insert", setIdentityInsert)
 	gorm.RegisterDialect("mssql", &mssql{})
 }
 


### PR DESCRIPTION
SET_IDENTITY_INSERT should be handled by each individual developer to avoid extra queries to the database. 

It also breaks most common use cases by being enabled by default.

Current implementation is also broken since it never disables SET_IDENTITY_INSERT, and it can only be enabled for one table at a time.