### PR TITLE
sqlite3: Never set primary key in-line

### DIFF
--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -27,20 +27,8 @@ func (s *sqlite3) DataTypeOf(field *StructField) string {
 		switch dataValue.Kind() {
 		case reflect.Bool:
 			sqlType = "bool"
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
-			if field.IsPrimaryKey {
-				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
-				sqlType = "integer primary key autoincrement"
-			} else {
-				sqlType = "integer"
-			}
-		case reflect.Int64, reflect.Uint64:
-			if field.IsPrimaryKey {
-				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
-				sqlType = "integer primary key autoincrement"
-			} else {
-				sqlType = "bigint"
-			}
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr, reflect.Int64, reflect.Uint64:
+			sqlType = "integer"
 		case reflect.Float32, reflect.Float64:
 			sqlType = "real"
 		case reflect.String:


### PR DESCRIPTION
Never set the primary key flag as part of the column definition. When
using sqlite3, this prevents mixed int/other type composite primary
key (because the int column always wins and get the index for itself).

Rather, let's just set the primary key at the end, whether it's composite
or not. Note that the int key will automatically be AUTOINCREMENT if
its type is "integer". For that reason, always use that type, rather
than "bigint", as bigint maps to "integer" eventually anyway.