### PR TITLE
Fix empty string as order/sort clause

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -360,6 +360,11 @@ func TestOrderAndPluck(t *testing.T) {
 		t.Errorf("Order with multiple orders")
 	}
 
+	var ages6 []int64
+	if err := scopedb.Order("").Pluck("age", &ages6).Error; err != nil {
+		t.Errorf("An empty string as order clause produces invalid queries")
+	}
+
 	DB.Model(User{}).Select("name, age").Find(&[]User{})
 }
 

--- a/search.go
+++ b/search.go
@@ -67,7 +67,7 @@ func (s *search) Order(value interface{}, reorder ...bool) *search {
 		s.orders = []interface{}{}
 	}
 
-	if value != nil {
+	if value != nil && value != "" {
 		s.orders = append(s.orders, value)
 	}
 	return s


### PR DESCRIPTION
Hi,

First of all, thanks and congratulations for this great project. I apologize in advance if i'm wrong and if I'm putting my hand where I should not.

After update one of my projects to the last development version of GORM, I have found a little bug in the sort function when executing queries. The problem appears when you **pass** an **empty string** to the sort/order function which currently produces an SQL syntax error. 

Example: 
```go
sortBy := ""
if useCustomSort() {
    sortBy = buildSortClause()
}
db.Order(sortBy).Find(&users)

Result:
Error 1064: You have an error in your SQL syntax; check the manual...
```

After review the [search.go](https://github.com/jinzhu/gorm/blob/master/search.go) file history changes, I have found that the problem was introduced by "[Add ORDER BY sql expression support](https://github.com/jinzhu/gorm/commit/c1c4f9f86e732a042aac9f37e025893d6d6cabec#diff-059dc0366ae402fcb2b70107da19b22d)" commit with the **Order function** changes.

I know that with the current logic, I could pass the **reorder** parameter to true, but I think it may be more correct to make the checks inside the function. 

Again, sorry if I am wrong and if I have wasted your time.