### PR TITLE
Fix ToDBName method

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -97,6 +97,9 @@ func ToDBName(name string) string {
 				}
 			} else {
 				buf.WriteRune(v)
+				if i == len(value)-2 && nextCase == upper {
+					buf.WriteRune('_')
+				}
 			}
 		} else {
 			currCase = upper

--- a/utils_test.go
+++ b/utils_test.go
@@ -9,11 +9,13 @@ import (
 func TestToDBNameGenerateFriendlyName(t *testing.T) {
 	var maps = map[string]string{
 		"":                          "",
+		"X":                         "x",
 		"ThisIsATest":               "this_is_a_test",
 		"PFAndESI":                  "pf_and_esi",
 		"AbcAndJkl":                 "abc_and_jkl",
 		"EmployeeID":                "employee_id",
 		"SKU_ID":                    "sku_id",
+		"FieldX":                    "field_x",
 		"HTTPAndSMTP":               "http_and_smtp",
 		"HTTPServerHandlerForURLID": "http_server_handler_for_url_id",
 		"UUID":     "uuid",


### PR DESCRIPTION
Thank you very much for letting me use it very conveniently

The behavior of the ToDBName method when the last capital letter comes in like FieldX has been corrected
FieldX becomes fieldx if it wants to become field_x

I am glad if you check it