### PR TITLE
prevent nil pointer dereference on closed connection

### DIFF
--- a/main.go
+++ b/main.go
@@ -452,7 +452,7 @@ func (s *DB) Debug() *DB {
 // Begin begin a transaction
 func (s *DB) Begin() *DB {
 	c := s.clone()
-	if db, ok := c.db.(sqlDb); ok {
+	if db, ok := c.db.(sqlDb); ok && db != nil {
 		tx, err := db.Begin()
 		c.db = interface{}(tx).(SQLCommon)
 		c.AddError(err)
@@ -464,7 +464,7 @@ func (s *DB) Begin() *DB {
 
 // Commit commit a transaction
 func (s *DB) Commit() *DB {
-	if db, ok := s.db.(sqlTx); ok {
+	if db, ok := s.db.(sqlTx); ok && db != nil {
 		s.AddError(db.Commit())
 	} else {
 		s.AddError(ErrInvalidTransaction)
@@ -474,7 +474,7 @@ func (s *DB) Commit() *DB {
 
 // Rollback rollback a transaction
 func (s *DB) Rollback() *DB {
-	if db, ok := s.db.(sqlTx); ok {
+	if db, ok := s.db.(sqlTx); ok && db != nil {
 		s.AddError(db.Rollback())
 	} else {
 		s.AddError(ErrInvalidTransaction)


### PR DESCRIPTION
fixes 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x645406]

goroutine 8 [running]:
panic(0x924a60, 0xc42000c0f0)
        /home/slayer/.gvm/gos/go1.7/src/runtime/panic.go:500 +0x1a1
database/sql.(*Tx).Commit(0x0, 0x7f3836324fa8, 0x0)
        /home/slayer/.gvm/gos/go1.7/src/database/sql/sql.go:1249 +0x26
github.com/jinzhu/gorm.(*DB).Commit(0xc43f079710, 0x9b3978)
        /home/slayer/.gvm/pkgsets/go1.7/global/src/github.com/jinzhu/gorm/main.go:463 +0x81
```