### PR TITLE
Adding more complete binary support for standard dialects

### DIFF
--- a/dialect_common.go
+++ b/dialect_common.go
@@ -149,3 +149,8 @@ func (DefaultForeignKeyNamer) BuildForeignKeyName(tableName, field, dest string)
 	keyName = regexp.MustCompile("(_*[^a-zA-Z]+_*|_+)").ReplaceAllString(keyName, "_")
 	return keyName
 }
+
+// IsByteArrayOrSlice returns true of the reflected value is an array or slice
+func IsByteArrayOrSlice(value reflect.Value) bool {
+	return (value.Kind() == reflect.Array || value.Kind() == reflect.Slice) && value.Type().Elem() == reflect.TypeOf(uint8(0))
+}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -87,7 +87,7 @@ func (s *mysql) DataTypeOf(field *StructField) string {
 				}
 			}
 		default:
-			if _, ok := dataValue.Interface().([]byte); ok {
+			if IsByteArrayOrSlice(dataValue) {
 				if size > 0 && size < 65532 {
 					sqlType = fmt.Sprintf("varbinary(%d)", size)
 				} else {

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -65,7 +65,7 @@ func (s *postgres) DataTypeOf(field *StructField) string {
 				sqlType = "hstore"
 			}
 		default:
-			if isByteArrayOrSlice(dataValue) {
+			if IsByteArrayOrSlice(dataValue) {
 				sqlType = "bytea"
 			} else if isUUID(dataValue) {
 				sqlType = "uuid"
@@ -118,10 +118,6 @@ func (s postgres) LastInsertIDReturningSuffix(tableName, key string) string {
 
 func (postgres) SupportLastInsertID() bool {
 	return false
-}
-
-func isByteArrayOrSlice(value reflect.Value) bool {
-	return (value.Kind() == reflect.Array || value.Kind() == reflect.Slice) && value.Type().Elem() == reflect.TypeOf(uint8(0))
 }
 
 func isUUID(value reflect.Value) bool {

--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -54,7 +54,7 @@ func (s *sqlite3) DataTypeOf(field *StructField) string {
 				sqlType = "datetime"
 			}
 		default:
-			if _, ok := dataValue.Interface().([]byte); ok {
+			if IsByteArrayOrSlice(dataValue) {
 				sqlType = "blob"
 			}
 		}

--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -58,21 +58,21 @@ func (s *mssql) DataTypeOf(field *gorm.StructField) string {
 		case reflect.Float32, reflect.Float64:
 			sqlType = "float"
 		case reflect.String:
-			if size > 0 && size < 65532 {
+			if size > 0 && size < 8000 {
 				sqlType = fmt.Sprintf("nvarchar(%d)", size)
 			} else {
-				sqlType = "text"
+				sqlType = "nvarchar(max)"
 			}
 		case reflect.Struct:
 			if _, ok := dataValue.Interface().(time.Time); ok {
 				sqlType = "datetime2"
 			}
 		default:
-			if _, ok := dataValue.Interface().([]byte); ok {
-				if size > 0 && size < 65532 {
-					sqlType = fmt.Sprintf("varchar(%d)", size)
+			if gorm.IsByteArrayOrSlice(dataValue) {
+				if size > 0 && size < 8000 {
+					sqlType = fmt.Sprintf("varbinary(%d)", size)
 				} else {
-					sqlType = "text"
+					sqlType = "varbinary(max)"
 				}
 			}
 		}


### PR DESCRIPTION
1. Sqllite would not support slices, so objects like:

```
type MyByteSlice []byte
```

would crashing on auto-migrate. 

2. MSSQL needs to use varbinary or image to avoid codepage issues and conflicts. 

3. Exported the previously private IsByteArrayOrSlice (originally in dialect_postgres.go), so it can be used generically throughout.