### PR TITLE
DB errors over NotFound

### DIFF
--- a/callback_query.go
+++ b/callback_query.go
@@ -80,9 +80,7 @@ func queryCallback(scope *Scope) {
 
 			if err := rows.Err(); err != nil {
 				scope.Err(err)
-			}
-
-			if scope.db.RowsAffected == 0 && !isSlice {
+			} else if scope.db.RowsAffected == 0 && !isSlice {
 				scope.Err(ErrRecordNotFound)
 			}
 		}


### PR DESCRIPTION
Errors comings from DB have higher priority than logic ones.

Even if it's correct to emit a ErrRecordNotFound it is misleading as the following ( common ) use case:

```go
if db.RecordNotFound() {
    /* 404 */
} else if db.Error != nil {
    /* 500 */
}
```

Note that the opposite usage is not possible as `ErrRecordNotFound` is part of db.Error, leading to 500 when it should be a 404.
A better solution is to manage ErrRecordNotFound differently from db ones, such that `db.Error` and `db.GetErrors()` does not include it as it is not an error but a normal and expected result.

Thank you in advance for your time and all the great work you did so far :blush: 

