### PR TITLE
gorm:auto_preload setting to enable auto preloading associations

### DIFF
--- a/callback_query_preload.go
+++ b/callback_query_preload.go
@@ -4,11 +4,17 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
 // preloadCallback used to preload associations
 func preloadCallback(scope *Scope) {
+
+	if _, ok := scope.Get("gorm:auto_preload"); ok {
+		autoPreload(scope)
+	}
+
 	if scope.Search.preload == nil || scope.HasError() {
 		return
 	}
@@ -76,6 +82,25 @@ func preloadCallback(scope *Scope) {
 				}
 			}
 		}
+	}
+}
+
+func autoPreload(scope *Scope) {
+	for _, field := range scope.Fields() {
+		if field.Relationship == nil {
+			continue
+		}
+
+		if val, ok := field.TagSettings["PRELOAD"]; ok {
+			if preload, err := strconv.ParseBool(val); err != nil {
+				scope.Err(errors.New("invalid preload option"))
+				return
+			} else if !preload {
+				continue
+			}
+		}
+
+		scope.Search.Preload(field.Name)
 	}
 }
 

--- a/preload_test.go
+++ b/preload_test.go
@@ -96,6 +96,33 @@ func TestPreload(t *testing.T) {
 	}
 }
 
+func TestAutoPreload(t *testing.T) {
+	user1 := getPreloadUser("auto_user1")
+	DB.Save(user1)
+
+	preloadDB := DB.Set("gorm:auto_preload", true).Where("role = ?", "Preload")
+	var user User
+	preloadDB.Find(&user)
+	checkUserHasPreloadData(user, t)
+
+	user2 := getPreloadUser("auto_user2")
+	DB.Save(user2)
+
+	var users []User
+	preloadDB.Find(&users)
+
+	for _, user := range users {
+		checkUserHasPreloadData(user, t)
+	}
+
+	var users2 []*User
+	preloadDB.Find(&users2)
+
+	for _, user := range users2 {
+		checkUserHasPreloadData(*user, t)
+	}
+}
+
 func TestNestedPreload1(t *testing.T) {
 	type (
 		Level1 struct {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- []X New code/logic commented & tested
- [X] Write good commit message, try to squash your commits into a single one
- [] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?

This PR adds a scope feature setting gorm:auto_preload. This causes all association to preload, including nested objects. This is a convenience method to eliminate many calls to Preload() for larger models and ensure consistency when all association preloads are needed.
