### PR TITLE
Add methods do add and drop check constraints

### DIFF
--- a/main.go
+++ b/main.go
@@ -602,6 +602,22 @@ func (s *DB) AddForeignKey(field string, dest string, onDelete string, onUpdate 
 	return scope.db
 }
 
+// AddCheckConstraint Add check to the given scope, e.g:
+//     db.Model(&User{}).AddCheckConstraint("users_login_count_chk", "login_count >= 0")
+func (s *DB) AddCheckConstraint(constraintName, check string) *DB {
+	scope := s.clone().NewScope(s.Value)
+	scope.addCheckConstraint(constraintName, check)
+	return scope.db
+}
+
+// DropCheckConstraint Drop check constraint, e.g:
+//     db.Model(&User{}).DropCheckConstraint("users_login_count_chk")
+func (s *DB) DropCheckConstraint(constraintName string) *DB {
+	scope := s.clone().NewScope(s.Value)
+	scope.dropCheckConstraint(constraintName)
+	return scope.db
+}
+
 // Association start `Association Mode` to handler relations things easir in that mode, refer: https://jinzhu.github.io/gorm/associations.html#association-mode
 func (s *DB) Association(column string) *Association {
 	var err error

--- a/scope.go
+++ b/scope.go
@@ -1164,6 +1164,25 @@ func (scope *Scope) addForeignKey(field string, dest string, onDelete string, on
 	scope.Raw(fmt.Sprintf(query, scope.QuotedTableName(), scope.quoteIfPossible(keyName), scope.quoteIfPossible(field), dest, onDelete, onUpdate)).Exec()
 }
 
+func (scope *Scope) addCheckConstraint(constraintName, check string) {
+	q := fmt.Sprintf(
+		"ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s)",
+		scope.QuotedTableName(),
+		scope.quoteIfPossible(constraintName),
+		check,
+	)
+	scope.Raw(q).Exec()
+}
+
+func (scope *Scope) dropCheckConstraint(constraintName string) {
+	q := fmt.Sprintf(
+		"ALTER TABLE %s DROP CONSTRAINT %s",
+		scope.QuotedTableName(),
+		scope.quoteIfPossible(constraintName),
+	)
+	scope.Raw(q).Exec()
+}
+
 func (scope *Scope) removeIndex(indexName string) {
 	scope.Dialect().RemoveIndex(scope.TableName(), indexName)
 }


### PR DESCRIPTION
Ref #1020

Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [ ] Run `./build.sh` in `gh-pages` branch for document changes

### What did this pull request do?

Adds `AddCheckConstraint` and `DropCheckConstraint` methods.

Just like `AddForeignKey`, these two methods won't work on SQLite, which require them to be created in the `CREATE TABLE` sentense, but is not possible on a `ALTER TABLE`.