### PR TITLE
Updated scope.go to always quote when adding index

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -448,7 +448,7 @@ func (scope *Scope) callMethod(methodName string, reflectValue reflect.Value) {
 }
 
 var (
-	columnRegexp        = regexp.MustCompile("^[a-zA-Z]+(\\.[a-zA-Z]+)*$") // only match string like `name`, `users.name`
+	columnRegexp        = regexp.MustCompile("^[a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*$") // only match string like `name`, `users.name`
 	isNumberRegexp      = regexp.MustCompile("^\\s*\\d+\\s*$")             // match if string is number
 	comparisonRegexp    = regexp.MustCompile("(?i) (=|<>|>|<|LIKE|IS|IN) ")
 	countingQueryRegexp = regexp.MustCompile("(?i)^count(.+)$")
@@ -1143,7 +1143,7 @@ func (scope *Scope) addIndex(unique bool, indexName string, column ...string) {
 
 	var columns []string
 	for _, name := range column {
-		columns = append(columns, scope.Quote(name))
+		columns = append(columns, scope.quoteIfPossible(name))
 	}
 
 	sqlCreate := "CREATE INDEX"

--- a/scope.go
+++ b/scope.go
@@ -1143,7 +1143,7 @@ func (scope *Scope) addIndex(unique bool, indexName string, column ...string) {
 
 	var columns []string
 	for _, name := range column {
-		columns = append(columns, scope.quoteIfPossible(name))
+		columns = append(columns, scope.Quote(name))
 	}
 
 	sqlCreate := "CREATE INDEX"

--- a/scope.go
+++ b/scope.go
@@ -449,7 +449,7 @@ func (scope *Scope) callMethod(methodName string, reflectValue reflect.Value) {
 
 var (
 	columnRegexp        = regexp.MustCompile("^[a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*$") // only match string like `name`, `users.name`
-	isNumberRegexp      = regexp.MustCompile("^\\s*\\d+\\s*$")             // match if string is number
+	isNumberRegexp      = regexp.MustCompile("^\\s*\\d+\\s*$")                   // match if string is number
 	comparisonRegexp    = regexp.MustCompile("(?i) (=|<>|>|<|LIKE|IS|IN) ")
 	countingQueryRegexp = regexp.MustCompile("(?i)^count(.+)$")
 )


### PR DESCRIPTION
I am using numbers for column names (to be compatible with protobuf) and adding unique index to them does not work since they are not quoted. I do not see a reason to check if the column name is a string in order to quote it. Correct me if I am wrong.