### PR TITLE
Changed the type of uint32 from integer to bigint in postgres

### DIFF
--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -30,14 +30,14 @@ func (s *postgres) DataTypeOf(field *StructField) string {
 		switch dataValue.Kind() {
 		case reflect.Bool:
 			sqlType = "boolean"
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uintptr:
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uintptr:
 			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "serial"
 			} else {
 				sqlType = "integer"
 			}
-		case reflect.Int64, reflect.Uint64:
+		case reflect.Int64, reflect.Uint32, reflect.Uint64:
 			if _, ok := field.TagSettings["AUTO_INCREMENT"]; ok || field.IsPrimaryKey {
 				field.TagSettings["AUTO_INCREMENT"] = "AUTO_INCREMENT"
 				sqlType = "bigserial"


### PR DESCRIPTION
The integer type in postgres is 4 bytes. Since it is also signed, when using uint32 with high bit set you will get:
`pq: value "2854263694" is out of range for type integer`
To prevent this uint32 should be bigint in postgres.
