### PR TITLE
 support to fills data to nil struct pointer

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -130,6 +130,9 @@ func Expr(expression string, args ...interface{}) *expr {
 
 func indirect(reflectValue reflect.Value) reflect.Value {
 	for reflectValue.Kind() == reflect.Ptr {
+		if reflectValue.IsNil() && reflectValue.CanSet() {
+			reflectValue.Set(reflect.New(reflectValue.Type().Elem()))
+		}
 		reflectValue = reflectValue.Elem()
 	}
 	return reflectValue


### PR DESCRIPTION
支持类似这样的操作：
func userByID(id int)(user *User,err error){
    err = db.Find(&user,id).Error
    return
}

