### PR TITLE
Fix postgres dialect for databases with multiple schemas

### DIFF
--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -85,7 +85,7 @@ func (s *postgres) DataTypeOf(field *StructField) string {
 
 func (s postgres) HasIndex(tableName string, indexName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM pg_indexes WHERE tablename = $1 AND indexname = $2", tableName, indexName).Scan(&count)
+	s.db.QueryRow("SELECT count(*) FROM pg_indexes WHERE tablename = $1 AND indexname = $2 AND schemaname = CURRENT_SCHEMA()", tableName, indexName).Scan(&count)
 	return count > 0
 }
 
@@ -97,13 +97,13 @@ func (s postgres) HasForeignKey(tableName string, foreignKeyName string) bool {
 
 func (s postgres) HasTable(tableName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = $1 AND table_type = 'BASE TABLE'", tableName).Scan(&count)
+	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = $1 AND table_type = 'BASE TABLE' AND table_schema = CURRENT_SCHEMA()", tableName).Scan(&count)
 	return count > 0
 }
 
 func (s postgres) HasColumn(tableName string, columnName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.columns WHERE table_name = $1 AND column_name = $2", tableName, columnName).Scan(&count)
+	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.columns WHERE table_name = $1 AND column_name = $2 AND table_schema = CURRENT_SCHEMA()", tableName, columnName).Scan(&count)
 	return count > 0
 }
 


### PR DESCRIPTION
If a postgres database contains more than one
schema methods like HasTable(...) would return
true even if the current schema does not contain a
table with that name.

The [INFORMATION_SCHEMA](https://www.postgresql.org/docs/9.6/static/infoschema-tables.html) tables have a column 
named `table_schema` and the [pg_indexes](https://www.postgresql.org/docs/9.6/static/view-pg-indexes.html) table a 
similar one named `schemaname`.

I added a check to the `where` clause of the respective
queries to only look at the [current schema](https://www.postgresql.org/docs/9.6/static/functions-info.html).