### PR TITLE
Erros skip nil in Add function

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -29,6 +29,10 @@ func (errs Errors) GetErrors() []error {
 // Add adds an error
 func (errs Errors) Add(newErrors ...error) Errors {
 	for _, err := range newErrors {
+		if err == nil {
+			continue
+		}
+
 		if errors, ok := err.(Errors); ok {
 			errs = errs.Add(errors...)
 		} else {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [x] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?
To skip nil in `Add` .

I wrote the following code.
```
conn *gorm.DB
...
tx := conn.Begin()
var errs gorm.Errors
errs = errs.Add(tx.Delete(&foo).Error)
errs = errs.Add(tx.Delete(&bar).Error)

if errs.Error() != "" {
  tx.Rollback()
  return
}
...
```

I got the error.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x43e6f75]
```

I checked `errs` variable.
```
gorm.Errors{
  nil,
}
```

I think `Errors` doesn't need to have `nil`.
Or should I always write like this?
```
if err := tx.Delete(&foo).Error; err != nil {
  errs = errs.Add(err)
}
```

Is not it supposed that `nil` will be added?

Thanks!