### PR TITLE
Do not always override select on pluck

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -665,3 +665,27 @@ func TestSelectWithArrayInput(t *testing.T) {
 		t.Errorf("Should have selected both age and name")
 	}
 }
+
+func TestPluckWithSelect(t *testing.T) {
+	DB.Save(&User{Name: "matematik7", Age: 25})
+
+	var userAges []string
+	err := DB.Model(&User{}).Where("age = ?", 25).Select("name || ' - ' || age as user_age").Pluck("user_age", &userAges).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(userAges) != 1 || userAges[0] != "matematik7 - 25" {
+		t.Errorf("Should correctly pluck with select, got: %s", userAges)
+	}
+
+	userAges = userAges[:0]
+	err = DB.Model(&User{}).Where("age = ?", 25).Select("name || ' - ' || age as \"user_age\"").Pluck("user_age", &userAges).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(userAges) != 1 || userAges[0] != "matematik7 - 25" {
+		t.Errorf("Should correctly pluck with select, got: %s", userAges)
+	}
+}

--- a/scope.go
+++ b/scope.go
@@ -924,12 +924,28 @@ func (scope *Scope) initialize() *Scope {
 	return scope
 }
 
+func (scope *Scope) isQueryForColumn(query interface{}, column string) bool {
+	queryStr := fmt.Sprint(query)
+	if queryStr == column {
+		return true
+	}
+
+	if strings.HasSuffix(strings.ToLower(queryStr), "as "+column) {
+		return true
+	}
+
+	return false
+}
+
 func (scope *Scope) pluck(column string, value interface{}) *Scope {
 	dest := reflect.Indirect(reflect.ValueOf(value))
-	scope.Search.Select(column)
 	if dest.Kind() != reflect.Slice {
 		scope.Err(fmt.Errorf("results should be a slice, not %s", dest.Kind()))
 		return scope
+	}
+
+	if query, ok := scope.Search.selects["query"]; !ok || !scope.isQueryForColumn(query, column) {
+		scope.Search.Select(column)
 	}
 
 	rows, err := scope.rows()

--- a/scope.go
+++ b/scope.go
@@ -925,12 +925,16 @@ func (scope *Scope) initialize() *Scope {
 }
 
 func (scope *Scope) isQueryForColumn(query interface{}, column string) bool {
-	queryStr := fmt.Sprint(query)
+	queryStr := strings.ToLower(fmt.Sprint(query))
 	if queryStr == column {
 		return true
 	}
 
-	if strings.HasSuffix(strings.ToLower(queryStr), "as "+column) {
+	if strings.HasSuffix(queryStr, "as "+column) {
+		return true
+	}
+
+	if strings.HasSuffix(queryStr, "as \""+column+"\"") {
 		return true
 	}
 


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [x] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?

I want to run query like this:
`DB.Model(&Entry).Select("date_part('year', created_at) as year").Pluck("year", &years)`
The select statement was getting overriden by pluck.