### PR TITLE
Do not ignore order on distinct query

### DIFF
--- a/search.go
+++ b/search.go
@@ -2,7 +2,6 @@ package gorm
 
 import (
 	"fmt"
-	"regexp"
 )
 
 type search struct {
@@ -73,13 +72,7 @@ func (s *search) Order(value interface{}, reorder ...bool) *search {
 	return s
 }
 
-var distinctSQLRegexp = regexp.MustCompile(`(?i)distinct[^a-z]+[a-z]+`)
-
 func (s *search) Select(query interface{}, args ...interface{}) *search {
-	if distinctSQLRegexp.MatchString(fmt.Sprint(query)) {
-		s.ignoreOrderQuery = true
-	}
-
 	s.selects = map[string]interface{}{"query": query, "args": args}
 	return s
 }


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [ ] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [x] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?
I am trying to run query like this:
`DB.Model(&Entry{}).Select("DISTINCT date_part('year', created_at) as year").Order("year desc")`
And the years are not ordered. I am not sure what the reasoning behind ignoring order on distinct was, but I need the years ordered.
