### PR TITLE
makes DialectsMap public for easier registration of dialects using ex…

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -48,6 +48,7 @@ type Dialect interface {
 	CurrentDatabase() string
 }
 
+// DialectsMap map of registered dialects
 var DialectsMap = map[string]Dialect{}
 
 func newDialect(name string, db SQLCommon) Dialect {

--- a/dialect.go
+++ b/dialect.go
@@ -48,10 +48,10 @@ type Dialect interface {
 	CurrentDatabase() string
 }
 
-var dialectsMap = map[string]Dialect{}
+var DialectsMap = map[string]Dialect{}
 
 func newDialect(name string, db SQLCommon) Dialect {
-	if value, ok := dialectsMap[name]; ok {
+	if value, ok := DialectsMap[name]; ok {
 		dialect := reflect.New(reflect.TypeOf(value).Elem()).Interface().(Dialect)
 		dialect.SetDB(db)
 		return dialect
@@ -65,7 +65,7 @@ func newDialect(name string, db SQLCommon) Dialect {
 
 // RegisterDialect register new dialect
 func RegisterDialect(name string, dialect Dialect) {
-	dialectsMap[name] = dialect
+	DialectsMap[name] = dialect
 }
 
 // ParseFieldStructForDialect get field's sql data type


### PR DESCRIPTION
…isting values refs #1572

Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested
- [X] Write good commit message, try to squash your commits into a single one
- [NA] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?

Makes DialectsMap public so that its existing values can be referenced when registering a new driver/dialect that uses the same underlying driver, e.g. 
`gorm.RegisterDialect("cloudsqlpostgres", gorm.DialectsMap["postgres"])`
