### PR TITLE
Support cloudsqlpostgres dialect

### DIFF
--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -13,6 +13,7 @@ type postgres struct {
 
 func init() {
 	RegisterDialect("postgres", &postgres{})
+	RegisterDialect("cloudsqlpostgres", &postgres{})
 }
 
 func (postgres) GetName() string {


### PR DESCRIPTION
This is needed for proper cloud sql proxy.

see https://github.com/GoogleCloudPlatform/cloudsql-proxy and https://github.com/GoogleCloudPlatform/cloudsql-proxy/blob/master/proxy/dialers/postgres/hook_test.go for details.

With this patch the gorm dialect of cloudsqlpostgres is recognised as postgres.

Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested
Does not look like a unit testable commit.
- [X] Write good commit message, try to squash your commits into a single one
- [] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?
