### PR TITLE
bugfix for LimitAndOffsetSQL

### DIFF
--- a/dialect_common.go
+++ b/dialect_common.go
@@ -127,10 +127,11 @@ func (commonDialect) LimitAndOffsetSQL(limit, offset interface{}) (sql string) {
 		if parsedLimit, err := strconv.ParseInt(fmt.Sprint(limit), 0, 0); err == nil && parsedLimit >= 0 {
 			sql += fmt.Sprintf(" LIMIT %d", parsedLimit)
 		}
-	}
-	if offset != nil {
-		if parsedOffset, err := strconv.ParseInt(fmt.Sprint(offset), 0, 0); err == nil && parsedOffset >= 0 {
-			sql += fmt.Sprintf(" OFFSET %d", parsedOffset)
+
+		if offset != nil {
+			if parsedOffset, err := strconv.ParseInt(fmt.Sprint(offset), 0, 0); err == nil && parsedOffset >= 0 {
+				sql += fmt.Sprintf(" OFFSET %d", parsedOffset)
+			}
 		}
 	}
 	return

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -126,11 +126,11 @@ func (commonDialect) LimitAndOffsetSQL(limit, offset interface{}) (sql string) {
 	if limit != nil {
 		if parsedLimit, err := strconv.ParseInt(fmt.Sprint(limit), 0, 0); err == nil && parsedLimit >= 0 {
 			sql += fmt.Sprintf(" LIMIT %d", parsedLimit)
-		}
 
-		if offset != nil {
-			if parsedOffset, err := strconv.ParseInt(fmt.Sprint(offset), 0, 0); err == nil && parsedOffset >= 0 {
-				sql += fmt.Sprintf(" OFFSET %d", parsedOffset)
+			if offset != nil {
+				if parsedOffset, err := strconv.ParseInt(fmt.Sprint(offset), 0, 0); err == nil && parsedOffset >= 0 {
+					sql += fmt.Sprintf(" OFFSET %d", parsedOffset)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
if limit = -1 and offset >= 0, sql with only OFFSET but not LIMIT ahead will cause syntax error (test in mysql 5.6) as OFFSET is based on LIMIT.
