### PR TITLE
fix count() …

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -950,7 +950,12 @@ func (scope *Scope) pluck(column string, value interface{}) *Scope {
 
 func (scope *Scope) count(value interface{}) *Scope {
 	if query, ok := scope.Search.selects["query"]; !ok || !countingQueryRegexp.MatchString(fmt.Sprint(query)) {
-		scope.Search.Select("count(*)")
+		if len(scope.Search.group) != 0 {
+			scope.Search.Select("count(*) FROM ( SELECT count(*) ")
+			scope.Search.group += " ) AS count"
+		} else {
+			scope.Search.Select("count(*)")
+		}
 	}
 	scope.Search.ignoreOrderQuery = true
 	scope.Err(scope.row().Scan(value))


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?

COUNT（）函数逻辑有错误，本应该是在执行任何SQL的时候，都可以返回正确的行数。而现在复杂的SQL集合无法正确获取行数。

当前count函数，无法处理复杂的sql查询集合。如下：

```
db.Select("`node`.`*`").Table(`tableName` AS `node`,  `tableName` AS `parent`)).Where("`node`.`left` BETWEEN `parent`.`left` AND `parent`.`right`").Group("`node`.`id`").Count(&count)
```
经过修改后，已经可以支持此类复杂的套嵌查询Count了。
