### PR TITLE
Fixed handling of driver.Valuer 

### DIFF
--- a/migration_test.go
+++ b/migration_test.go
@@ -120,15 +120,15 @@ type EncryptedData []byte
 
 func (data *EncryptedData) Scan(value interface{}) error {
 	if b, ok := value.([]byte); ok {
-		if len(b) < 3 || b[0] != '*' || b[1] != '*' || b[2] != '*'{
+		if len(b) < 3 || b[0] != '*' || b[1] != '*' || b[2] != '*' {
 			return errors.New("Too short")
 		}
 
 		*data = b[3:]
 		return nil
-	} else {
-		return errors.New("Bytes expected")
 	}
+
+	return errors.New("Bytes expected")
 }
 
 func (data EncryptedData) Value() (driver.Value, error) {

--- a/scope.go
+++ b/scope.go
@@ -557,22 +557,29 @@ func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str stri
 
 	args := clause["args"].([]interface{})
 	for _, arg := range args {
-		switch reflect.ValueOf(arg).Kind() {
-		case reflect.Slice: // For where("id in (?)", []int64{1,2})
-			if bytes, ok := arg.([]byte); ok {
-				str = strings.Replace(str, "?", scope.AddToVars(bytes), 1)
-			} else if values := reflect.ValueOf(arg); values.Len() > 0 {
-				var tempMarks []string
-				for i := 0; i < values.Len(); i++ {
-					tempMarks = append(tempMarks, scope.AddToVars(values.Index(i).Interface()))
+		rArg := reflect.ValueOf(arg)
+		rArgType := reflect.TypeOf(arg)
+		vArg, isValuer := arg.(driver.Valuer)
+		var err error
+
+		//non byte slice and non driver.Valuer
+		if rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
+			if rArg.Len() > 0 {
+				tempMarks := make([]string, 0, rArg.Len())
+				for i := 0; i < rArg.Len(); i++ {
+					tempMarks = append(tempMarks, scope.AddToVars(rArg.Index(i).Interface()))
 				}
+
 				str = strings.Replace(str, "?", strings.Join(tempMarks, ","), 1)
 			} else {
 				str = strings.Replace(str, "?", scope.AddToVars(Expr("NULL")), 1)
 			}
-		default:
-			if valuer, ok := interface{}(arg).(driver.Valuer); ok {
-				arg, _ = valuer.Value()
+		} else {
+			if isValuer {
+				arg, err = vArg.Value()
+				if err != nil {
+					scope.Err(err)
+				}
 			}
 
 			str = strings.Replace(str, "?", scope.AddToVars(arg), 1)
@@ -629,23 +636,31 @@ func (scope *Scope) buildNotCondition(clause map[string]interface{}) (str string
 
 	args := clause["args"].([]interface{})
 	for _, arg := range args {
-		switch reflect.ValueOf(arg).Kind() {
-		case reflect.Slice: // For where("id in (?)", []int64{1,2})
-			if bytes, ok := arg.([]byte); ok {
-				str = strings.Replace(str, "?", scope.AddToVars(bytes), 1)
-			} else if values := reflect.ValueOf(arg); values.Len() > 0 {
-				var tempMarks []string
-				for i := 0; i < values.Len(); i++ {
-					tempMarks = append(tempMarks, scope.AddToVars(values.Index(i).Interface()))
+		rArg := reflect.ValueOf(arg)
+		rArgType := reflect.TypeOf(arg)
+		vArg, isValuer := arg.(driver.Valuer)
+		var err error
+
+		//non byte slice and non driver.Valuer
+		if rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
+			if rArg.Len() > 0 {
+				tempMarks := make([]string, 0, rArg.Len())
+				for i := 0; i < rArg.Len(); i++ {
+					tempMarks = append(tempMarks, scope.AddToVars(rArg.Index(i).Interface()))
 				}
+
 				str = strings.Replace(str, "?", strings.Join(tempMarks, ","), 1)
 			} else {
 				str = strings.Replace(str, "?", scope.AddToVars(Expr("NULL")), 1)
 			}
-		default:
-			if scanner, ok := interface{}(arg).(driver.Valuer); ok {
-				arg, _ = scanner.Value()
+		} else {
+			if isValuer {
+				arg, err = vArg.Value()
+				if err != nil {
+					scope.Err(err)
+				}
 			}
+
 			str = strings.Replace(notEqualSQL, "?", scope.AddToVars(arg), 1)
 		}
 	}
@@ -662,18 +677,31 @@ func (scope *Scope) buildSelectQuery(clause map[string]interface{}) (str string)
 
 	args := clause["args"].([]interface{})
 	for _, arg := range args {
-		switch reflect.ValueOf(arg).Kind() {
-		case reflect.Slice:
-			values := reflect.ValueOf(arg)
-			var tempMarks []string
-			for i := 0; i < values.Len(); i++ {
-				tempMarks = append(tempMarks, scope.AddToVars(values.Index(i).Interface()))
+		rArg := reflect.ValueOf(arg)
+		rArgType := reflect.TypeOf(arg)
+		vArg, isValuer := arg.(driver.Valuer)
+		var err error
+
+		//non byte slice and non driver.Valuer
+		if rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
+			if rArg.Len() > 0 {
+				tempMarks := make([]string, 0, rArg.Len())
+				for i := 0; i < rArg.Len(); i++ {
+					tempMarks = append(tempMarks, scope.AddToVars(rArg.Index(i).Interface()))
+				}
+
+				str = strings.Replace(str, "?", strings.Join(tempMarks, ","), 1)
+			} else {
+				str = strings.Replace(str, "?", scope.AddToVars(Expr("NULL")), 1)
 			}
-			str = strings.Replace(str, "?", strings.Join(tempMarks, ","), 1)
-		default:
-			if valuer, ok := interface{}(arg).(driver.Valuer); ok {
-				arg, _ = valuer.Value()
+		} else {
+			if isValuer {
+				arg, err = vArg.Value()
+				if err != nil {
+					scope.Err(err)
+				}
 			}
+
 			str = strings.Replace(str, "?", scope.AddToVars(arg), 1)
 		}
 	}

--- a/scope.go
+++ b/scope.go
@@ -563,7 +563,7 @@ func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str stri
 		var err error
 
 		//non byte slice and non driver.Valuer
-		if rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
+		if arg != nil && rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
 			if rArg.Len() > 0 {
 				tempMarks := make([]string, 0, rArg.Len())
 				for i := 0; i < rArg.Len(); i++ {
@@ -642,7 +642,7 @@ func (scope *Scope) buildNotCondition(clause map[string]interface{}) (str string
 		var err error
 
 		//non byte slice and non driver.Valuer
-		if rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
+		if arg != nil && rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
 			if rArg.Len() > 0 {
 				tempMarks := make([]string, 0, rArg.Len())
 				for i := 0; i < rArg.Len(); i++ {
@@ -683,7 +683,7 @@ func (scope *Scope) buildSelectQuery(clause map[string]interface{}) (str string)
 		var err error
 
 		//non byte slice and non driver.Valuer
-		if rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
+		if arg != nil && rArgType.Kind() == reflect.Slice && rArgType.Elem().Kind() != reflect.Uint8 && !isValuer {
 			if rArg.Len() > 0 {
 				tempMarks := make([]string, 0, rArg.Len())
 				for i := 0; i < rArg.Len(); i++ {


### PR DESCRIPTION
This PR fixes #1596 

It changes how slices are expanded when building WHERE conditions
```
db.Where("a = ?", param)
```

Current logic:
- If param is non byte slice - expand it
- If param is byte slice - use it as is (as binary data)
- If param is driver.Valuer - call param.Value() without checking for error
- Otherwise - use param as is

Slice types, even those that implement driver.Valuer were always expanded. So it was not possible to use custom slice types. For example: 

```
type EncryptedValue []byte

func (v EncryptedValue) Value() (driver.Value, error) {
...
}

func (v *EncryptedValue) Scan(value interface{}) error {
 ...
}
```

I replaced the logic with the following
- If param is non byte slice and non driver.Valuer - expand it
- If param is driver.Valuer - call param.Value() and **check for errors**
- Otherwise - use param as is


Also this change affects custom byte slice types which don't implement driver.Valuer
```
type BinData []byte
```

Previously such params were always expanded as slices. After the changes I made such param will be passed as is (as binary data)


