### PR TITLE
Correct ModifyColumn SQL syntax.

### DIFF
--- a/migration_test.go
+++ b/migration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -434,6 +435,13 @@ func TestMultipleIndexes(t *testing.T) {
 }
 
 func TestModifyColumnType(t *testing.T) {
+	dialect := os.Getenv("GORM_DIALECT")
+	if dialect != "postgres" &&
+		dialect != "mysql" &&
+		dialect != "mssql" {
+		t.Skip("Skipping this because only postgres, mysql and mssql support altering a column type")
+	}
+
 	type ModifyColumnType struct {
 		gorm.Model
 		Name1 string `gorm:"length:100"`

--- a/migration_test.go
+++ b/migration_test.go
@@ -432,3 +432,20 @@ func TestMultipleIndexes(t *testing.T) {
 		t.Error("MultipleIndexes unique index failed")
 	}
 }
+
+func TestModifyColumnType(t *testing.T) {
+	type ModifyColumnType struct {
+		gorm.Model
+		Name1 string `gorm:"length:100"`
+		Name2 string `gorm:"length:200"`
+	}
+	DB.DropTable(&ModifyColumnType{})
+	DB.CreateTable(&ModifyColumnType{})
+
+	name2Field, _ := DB.NewScope(&ModifyColumnType{}).FieldByName("Name2")
+	name2Type := DB.Dialect().DataTypeOf(name2Field.StructField)
+
+	if err := DB.Model(&ModifyColumnType{}).ModifyColumn("name1", name2Type).Error; err != nil {
+		t.Errorf("No error should happen when ModifyColumn, but got %v", err)
+	}
+}

--- a/scope.go
+++ b/scope.go
@@ -1139,7 +1139,7 @@ func (scope *Scope) dropTable() *Scope {
 }
 
 func (scope *Scope) modifyColumn(column string, typ string) {
-	scope.Raw(fmt.Sprintf("ALTER TABLE %v MODIFY %v %v", scope.QuotedTableName(), scope.Quote(column), typ)).Exec()
+	scope.Raw(fmt.Sprintf("ALTER TABLE %v ALTER COLUMN %v TYPE %v", scope.QuotedTableName(), scope.Quote(column), typ)).Exec()
 }
 
 func (scope *Scope) dropColumn(column string) {


### PR DESCRIPTION
The generated SQL for ModifyColumn was:

`ALTER TABLE "tablename" MODIFY "columname" type`

But should have been:

`ALTER TABLE "tablename" ALTER COLUMN "columname" TYPE type`

since Modify does not seem to be entirely compatible with all Engines

Make sure these boxes checked before submitting your pull request.

- [] Do only one thing
- [] No API-breaking changes
- [] New code/logic commented & tested
- [] Write good commit message, try to squash your commits into a single one
- [] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?
