### PR TITLE
Add the ability to set the default Logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -18,6 +18,11 @@ var (
 	numericPlaceHolderRegexp = regexp.MustCompile(`\$\d+`)
 )
 
+// SetDefaultLogger replaces the default Logger instance.
+func SetDefaultLogger(l Logger) {
+	defaultLogger = l
+}
+
 func isPrintable(s string) bool {
 	for _, r := range s {
 		if !unicode.IsPrint(r) {


### PR DESCRIPTION
Sometimes you want to have a default logger that is used for all of your database connections; you can now set the default logger using `gorm.SetDefaultLogger`.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [x] ~~Run `./build.sh` in `gh-pages` branch for document changes~~ not applicable?

### What did this pull request do?
This adds a `SetDefaultLogger` method to allow you to replace the default logger that `gorm` uses.

I did this for two reasons: first, I wanted to be 100% certain that any logs created during `gorm.Open()` got sent to the right place; second, I wanted to just set the logger once and have it be used for all DB connections.