### PR TITLE
Do not call TableName function via interface{}.

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -314,14 +314,6 @@ func (scope *Scope) TableName() string {
 		return scope.Search.tableName
 	}
 
-	if tabler, ok := scope.Value.(tabler); ok {
-		return tabler.TableName()
-	}
-
-	if tabler, ok := scope.Value.(dbTabler); ok {
-		return tabler.TableName(scope.db)
-	}
-
 	return scope.GetModelStruct().TableName(scope.db.Model(scope.Value))
 }
 


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [x] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?

If scope.Value implemts tabler interface,
DefaultTableNameHandler is never called.
But, if scope.Value is a slice of Model,
DefaultTableNameHandler is called.
DefaultTableNameHandler should always be called.

So, I removed the type assertion.