### PR TITLE
autoIndex should throw an error on failed

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -1228,11 +1228,19 @@ func (scope *Scope) autoIndex() *Scope {
 	}
 
 	for name, columns := range indexes {
-		scope.NewDB().Model(scope.Value).AddIndex(name, columns...)
+		db := scope.NewDB().Model(scope.Value).AddIndex(name, columns...)
+		if db.Error != nil {
+			scope.db.Error = db.Error
+			return scope
+		}
 	}
 
 	for name, columns := range uniqueIndexes {
-		scope.NewDB().Model(scope.Value).AddUniqueIndex(name, columns...)
+		db := scope.NewDB().Model(scope.Value).AddUniqueIndex(name, columns...)
+		if db.Error != nil {
+			scope.db.Error = db.Error
+			return scope
+		}
 	}
 
 	return scope


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested
- [X] Write good commit message, try to squash your commits into a single one
- [X] Run `./build.sh` in `gh-pages` branch for document changes

### What did this pull request do?

`autoIndex` should throw an error when it failed to create an index, such as when you use `AutoMigrate` or `CreateTable`.
