### PR TITLE
Allow name of column to be customized to support self-referencing many2many fields

### DIFF
--- a/customize_column_test.go
+++ b/customize_column_test.go
@@ -279,3 +279,25 @@ func TestBelongsToWithPartialCustomizedColumn(t *testing.T) {
 		t.Errorf("should preload discount from coupon")
 	}
 }
+
+type SelfReferencingUser struct {
+	gorm.Model
+	Friends []*SelfReferencingUser `gorm:"many2many:UserFriends;AssociationForeignKey:ID=friend_id"`
+}
+
+func TestSelfReferencingMany2ManyColumn(t *testing.T) {
+	DB.DropTable(&SelfReferencingUser{}, "UserFriends")
+	DB.AutoMigrate(&SelfReferencingUser{})
+
+	friend := SelfReferencingUser{}
+	if err := DB.Create(&friend).Error; err != nil {
+		t.Errorf("no error should happen, but got %v", err)
+	}
+
+	user := SelfReferencingUser{
+		Friends: []*SelfReferencingUser{&friend},
+	}
+	if err := DB.Create(&user).Error; err != nil {
+		t.Errorf("no error should happen, but got %v", err)
+	}
+}

--- a/model_struct.go
+++ b/model_struct.go
@@ -289,11 +289,24 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 									}
 
 									for _, name := range associationForeignKeys {
+
+										// In order to allow self-referencing many2many tables, the name
+										// may be followed by "=" to allow renaming the column
+										parts := strings.Split(name, "=")
+										name = parts[0]
+
 										if field, ok := toScope.FieldByName(name); ok {
 											// association foreign keys (db names)
 											relationship.AssociationForeignFieldNames = append(relationship.AssociationForeignFieldNames, field.DBName)
+
+											// If a new name was provided for the field, use it
+											name = field.DBName
+											if len(parts) > 1 {
+												name = parts[1]
+											}
+
 											// join table foreign keys for association
-											joinTableDBName := ToDBName(elemType.Name()) + "_" + field.DBName
+											joinTableDBName := ToDBName(elemType.Name()) + "_" + name
 											relationship.AssociationForeignDBNames = append(relationship.AssociationForeignDBNames, joinTableDBName)
 										}
 									}


### PR DESCRIPTION
This pull request attempts to solve issue #1194 without breaking anything else. This is accomplished by allowing the `AssociationForeignKey` tag to specify the name for the column in the database:

    type User struct {
        //...
        Friends []*User `gorm:"many2many:user_friends;AssociationForeignKey:ID=friend_id"`
    }

Notice the addition of the `=friend_id`. This addition is optional, which allows existing code to continue to work exactly the way it did before. Models that require a self-referencing many-to-many field can use the expanded syntax.

In `join_table_handler.go`, it became clear that `getSearchMap()` wasn't going to work in `Add()` since the `s.Source.ModelType == modelType` expression would evaluate to `true` for both the source and the destination models. Therefore, I adapted `Add()` to loop through the source and destination fields individually, ensuring that the correct scope was used.

The new changes also include a test.