### PR TITLE
When using postgres, don't use prepare statement, instance of compose sql manually

### DIFF
--- a/create_test.go
+++ b/create_test.go
@@ -12,7 +12,7 @@ import (
 func TestCreate(t *testing.T) {
 	float := 35.03554004971999
 	now := time.Now()
-	user := User{Name: "CreateUser", Age: 18, Birthday: &now, UserNum: Num(111), PasswordHash: []byte{'f', 'a', 'k', '4'}, Latitude: float}
+	user := User{Name: "CreateUser", Age: 18, Birthday: &now, UserNum: Num(111), PasswordHash: []byte{0, 'f', 'a', 'k', '4'}, Latitude: float}
 
 	if !DB.NewRecord(user) || !DB.NewRecord(&user) {
 		t.Error("User should be new record before create")
@@ -29,7 +29,7 @@ func TestCreate(t *testing.T) {
 	var newUser User
 	DB.First(&newUser, user.Id)
 
-	if !reflect.DeepEqual(newUser.PasswordHash, []byte{'f', 'a', 'k', '4'}) {
+	if !reflect.DeepEqual(newUser.PasswordHash, []byte{0, 'f', 'a', 'k', '4'}) {
 		t.Errorf("User's PasswordHash should be saved ([]byte)")
 	}
 

--- a/dialect.go
+++ b/dialect.go
@@ -16,6 +16,9 @@ type Dialect interface {
 	// SetDB set db for dialect
 	SetDB(db SQLCommon)
 
+	// StringifyVar return escape string of var
+	StringifyVar(value interface{}) (string, bool)
+
 	// BindVar return the placeholder for actual values in SQL statements, in many dbs it is "?", Postgres using $1
 	BindVar(i int) string
 	// Quote quotes field name to avoid SQL parsing exceptions by using a reserved word as a field name

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -30,6 +30,10 @@ func (s *commonDialect) SetDB(db SQLCommon) {
 	s.db = db
 }
 
+func (commonDialect) StringifyVar(value interface{}) (string, bool) {
+	return "", false
+}
+
 func (commonDialect) BindVar(i int) string {
 	return "$$$" // ?
 }

--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -49,6 +49,10 @@ func (s *mssql) SetDB(db gorm.SQLCommon) {
 	s.db = db
 }
 
+func (mssql) StringifyVar(value interface{}) (string, bool) {
+	return "", false
+}
+
 func (mssql) BindVar(i int) string {
 	return "$$$" // ?
 }

--- a/logger.go
+++ b/logger.go
@@ -79,10 +79,13 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 				}
 			} else {
 				formattedValuesLength := len(formattedValues)
-				for index, value := range sqlRegexp.Split(values[3].(string), -1) {
+				s := sqlRegexp.Split(values[3].(string), -1)
+				for index, value := range s {
 					sql += value
 					if index < formattedValuesLength {
 						sql += formattedValues[index]
+					} else if index != len(s)-1 {
+						sql += "?"
 					}
 				}
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -393,6 +393,13 @@ func TestRow(t *testing.T) {
 	if age != 10 {
 		t.Errorf("Scan with Row")
 	}
+
+	age = 0
+	row = DB.Debug().Table("users").Where("name != ? AND name != ? AND Age = ? AND name != ?", "???", "???", 10, "???").Select("age").Row()
+	row.Scan(&age)
+	if age != 10 {
+		t.Errorf("Scan with Row")
+	}
 }
 
 func TestRows(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -727,6 +727,7 @@ func TestHstore(t *testing.T) {
 		"bankAccountId": &bankAccountId,
 		"phoneNumber":   &phoneNumber,
 		"opinion":       &opinion,
+		"nil":           nil,
 	}
 	d := Details{Bulk: bulk}
 	DB.Save(&d)
@@ -738,8 +739,15 @@ func TestHstore(t *testing.T) {
 
 	for k := range bulk {
 		if r, ok := d2.Bulk[k]; ok {
-			if res, _ := bulk[k]; *res != *r {
-				t.Errorf("Details should be equal")
+			res, _ := bulk[k]
+			if res == nil || r == nil {
+				if res != r {
+					t.Errorf("Details should be equal")
+				}
+			} else {
+				if *res != *r {
+					t.Errorf("Details should be equal")
+				}
 			}
 		} else {
 			t.Errorf("Details should be existed")

--- a/scope.go
+++ b/scope.go
@@ -261,7 +261,7 @@ func (scope *Scope) AddToVars(value interface{}) string {
 			if skipBindVar {
 				scope.AddToVars(arg)
 			} else {
-				exp = strings.Replace(exp, "?", scope.AddToVars(arg), 1)
+				exp = scope.ReplaceOnePlaceholder(exp, scope.AddToVars(arg))
 			}
 		}
 		return exp
@@ -278,6 +278,20 @@ func (scope *Scope) AddToVars(value interface{}) string {
 		return "?"
 	}
 	return dialect.BindVar(len(scope.SQLVars))
+}
+
+func (scope *Scope) ReplaceOnePlaceholder(sql, value string) string {
+	quoteCount := 0
+	for idx, c := range sql {
+		if string(c) == "'" {
+			quoteCount += 1
+			continue
+		}
+		if string(c) == "?" && quoteCount%2 == 0 {
+			return string([]rune(sql)[:idx]) + value + string([]rune(sql)[idx+1:])
+		}
+	}
+	return sql
 }
 
 // SelectAttrs return selected attributes
@@ -565,22 +579,21 @@ func (scope *Scope) buildWhereCondition(clause map[string]interface{}) (str stri
 		switch reflect.ValueOf(arg).Kind() {
 		case reflect.Slice: // For where("id in (?)", []int64{1,2})
 			if bytes, ok := arg.([]byte); ok {
-				str = strings.Replace(str, "?", scope.AddToVars(bytes), 1)
+				str = scope.ReplaceOnePlaceholder(str, scope.AddToVars(bytes))
 			} else if values := reflect.ValueOf(arg); values.Len() > 0 {
 				var tempMarks []string
 				for i := 0; i < values.Len(); i++ {
 					tempMarks = append(tempMarks, scope.AddToVars(values.Index(i).Interface()))
 				}
-				str = strings.Replace(str, "?", strings.Join(tempMarks, ","), 1)
+				str = scope.ReplaceOnePlaceholder(str, strings.Join(tempMarks, ","))
 			} else {
-				str = strings.Replace(str, "?", scope.AddToVars(Expr("NULL")), 1)
+				str = scope.ReplaceOnePlaceholder(str, scope.AddToVars(Expr("NULL")))
 			}
 		default:
 			if valuer, ok := interface{}(arg).(driver.Valuer); ok {
 				arg, _ = valuer.Value()
 			}
-
-			str = strings.Replace(str, "?", scope.AddToVars(arg), 1)
+			str = scope.ReplaceOnePlaceholder(str, scope.AddToVars(arg))
 		}
 	}
 	return
@@ -637,21 +650,21 @@ func (scope *Scope) buildNotCondition(clause map[string]interface{}) (str string
 		switch reflect.ValueOf(arg).Kind() {
 		case reflect.Slice: // For where("id in (?)", []int64{1,2})
 			if bytes, ok := arg.([]byte); ok {
-				str = strings.Replace(str, "?", scope.AddToVars(bytes), 1)
+				str = scope.ReplaceOnePlaceholder(str, scope.AddToVars(bytes))
 			} else if values := reflect.ValueOf(arg); values.Len() > 0 {
 				var tempMarks []string
 				for i := 0; i < values.Len(); i++ {
 					tempMarks = append(tempMarks, scope.AddToVars(values.Index(i).Interface()))
 				}
-				str = strings.Replace(str, "?", strings.Join(tempMarks, ","), 1)
+				str = scope.ReplaceOnePlaceholder(str, strings.Join(tempMarks, ","))
 			} else {
-				str = strings.Replace(str, "?", scope.AddToVars(Expr("NULL")), 1)
+				str = scope.ReplaceOnePlaceholder(str, scope.AddToVars(Expr("NULL")))
 			}
 		default:
 			if scanner, ok := interface{}(arg).(driver.Valuer); ok {
 				arg, _ = scanner.Value()
 			}
-			str = strings.Replace(notEqualSQL, "?", scope.AddToVars(arg), 1)
+			str = scope.ReplaceOnePlaceholder(notEqualSQL, scope.AddToVars(arg))
 		}
 	}
 	return
@@ -674,12 +687,12 @@ func (scope *Scope) buildSelectQuery(clause map[string]interface{}) (str string)
 			for i := 0; i < values.Len(); i++ {
 				tempMarks = append(tempMarks, scope.AddToVars(values.Index(i).Interface()))
 			}
-			str = strings.Replace(str, "?", strings.Join(tempMarks, ","), 1)
+			str = scope.ReplaceOnePlaceholder(str, strings.Join(tempMarks, ","))
 		default:
 			if valuer, ok := interface{}(arg).(driver.Valuer); ok {
 				arg, _ = valuer.Value()
 			}
-			str = strings.Replace(str, "?", scope.AddToVars(arg), 1)
+			str = scope.ReplaceOnePlaceholder(str, scope.AddToVars(arg))
 		}
 	}
 	return
@@ -765,7 +778,7 @@ func (scope *Scope) orderSQL() string {
 		} else if expr, ok := order.(*expr); ok {
 			exp := expr.expr
 			for _, arg := range expr.args {
-				exp = strings.Replace(exp, "?", scope.AddToVars(arg), 1)
+				exp = scope.ReplaceOnePlaceholder(exp, scope.AddToVars(arg))
 			}
 			orders = append(orders, exp)
 		}

--- a/scope.go
+++ b/scope.go
@@ -267,12 +267,17 @@ func (scope *Scope) AddToVars(value interface{}) string {
 		return exp
 	}
 
+	dialect := scope.Dialect()
+	if str, ok := dialect.StringifyVar(value); ok {
+		return str
+	}
+
 	scope.SQLVars = append(scope.SQLVars, value)
 
 	if skipBindVar {
 		return "?"
 	}
-	return scope.Dialect().BindVar(len(scope.SQLVars))
+	return dialect.BindVar(len(scope.SQLVars))
 }
 
 // SelectAttrs return selected attributes


### PR DESCRIPTION
When using gorm with pgbouncer transaction mode, we face a problem.
Pgbouncer transaction mode doesn't support prepare statement, and gorm always use it.
So in this pr, I compose postgres sql instead of using prepare statement.
Therefore gorm can work fine with pgbouncer transaction mode.

In the meanwhile, I change "?" replacing logic.
Because of if the previous variable contain with "?", the next variable may be replaced in wrong position.