### PR TITLE
Fix regex in BuildForeignKeyName #1681

### DIFF
--- a/dialect_common.go
+++ b/dialect_common.go
@@ -146,7 +146,7 @@ func (commonDialect) LastInsertIDReturningSuffix(tableName, columnName string) s
 
 func (DefaultForeignKeyNamer) BuildForeignKeyName(tableName, field, dest string) string {
 	keyName := fmt.Sprintf("%s_%s_%s_foreign", tableName, field, dest)
-	keyName = regexp.MustCompile("(_*[^a-zA-Z]+_*|_+)").ReplaceAllString(keyName, "_")
+	keyName = regexp.MustCompile("[^a-zA-Z0-9]+").ReplaceAllString(keyName, "_")
 	return keyName
 }
 

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -166,8 +166,8 @@ func (s mysql) BuildForeignKeyName(tableName, field, dest string) string {
 	h.Write([]byte(keyName))
 	bs := h.Sum(nil)
 
-	// sha1 is 40 digits, keep first 24 characters of destination
-	destRunes := []rune(regexp.MustCompile("(_*[^a-zA-Z]+_*|_+)").ReplaceAllString(dest, "_"))
+	// sha1 is 40 characters, keep first 24 characters of destination
+	destRunes := []rune(regexp.MustCompile("[^a-zA-Z0-9]+").ReplaceAllString(dest, "_"))
 	if len(destRunes) > 24 {
 		destRunes = destRunes[:24]
 	}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?

Fix #1681

#### Current master branch

https://github.com/jinzhu/gorm/blob/0a51f6cdc55d1650d9ed3b4c13026cfa9133b01e/dialect_common.go#L147-L151

`(_*[^a-zA-Z]+_*|_+)`

```go
db.Model(&Example{}).AddForeignKey("__example6__id_", "_example1_(_id0__)__", "RESTRICT", "RESTRICT")
// => examples_example_id_example_id_foreign
```

#### This PR

`[^a-zA-Z0-9]+`

```go
db.Model(&Example{}).AddForeignKey("__example6__id_", "_example1_(_id0__)__", "RESTRICT", "RESTRICT")
// => examples_example6_id_example1_id0_foreign
```
