### PR TITLE
remove sslmode=disable from postgresql docu

### DIFF
--- a/documents/database.md
+++ b/documents/database.md
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-  db, err := gorm.Open("postgres", "host=myhost port=myport user=gorm dbname=gorm sslmode=disable password=mypassword")
+  db, err := gorm.Open("postgres", "host=myhost port=myport user=gorm dbname=gorm password=mypassword")
   defer db.Close()
 }
 ```


### PR DESCRIPTION
remove ```sslmode=disable``` from postgresql which leads to unsafe copy and paste situations
