### PR TITLE
Allow for proper table creation with Jsonb fields

### DIFF
--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	"encoding/json"
 )
 
 type postgres struct {
@@ -67,9 +68,12 @@ func (s *postgres) DataTypeOf(field *StructField) string {
 			}
 		default:
 			if IsByteArrayOrSlice(dataValue) {
-				sqlType = "bytea"
 				if isUUID(dataValue) {
 					sqlType = "uuid"
+				} else if _, ok := dataValue.Interface().(json.RawMessage); ok {
+					sqlType = "jsonb"
+				} else {
+					sqlType = "bytea"
 				}
 			}
 		}


### PR DESCRIPTION
### What did this pull request do?
This fixes the issue mentioned by @buildascientist in https://github.com/jinzhu/gorm/issues/1183 (unsure if I should create a new issue for this, since it's technically related to "supporting jsonb fields"). 

It allows gorm to properly handle creating a table (````dbHandle.CreateTable(<your_struct>)````) with "Jsonb" structs by identifying them as "jsonb" columns instead of "bytea" columns.