### PR TITLE
Added Scope After Scan Method Callback

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/field.go
+++ b/field.go
@@ -14,6 +14,15 @@ type Field struct {
 	Field   reflect.Value
 }
 
+func (field *Field) CallMethodCallbackArgs(name string, object reflect.Value, in []reflect.Value) {
+	field.StructField.CallMethodCallbackArgs(name, object, append([]reflect.Value{reflect.ValueOf(field)}, in...))
+}
+
+// Call the method callback
+func (field *Field) CallMethodCallback(name string, object reflect.Value, in ...reflect.Value) {
+	field.CallMethodCallbackArgs(name, object, in)
+}
+
 // Set set a value to the field
 func (field *Field) Set(value interface{}) (err error) {
 	if !field.Field.IsValid() {

--- a/main.go
+++ b/main.go
@@ -808,7 +808,7 @@ func (s *DB) EnableAfterScanCallback(typs ...interface{}) *DB  {
 
 // Return if after scan callbacks has be enable. If typs is empty, return default, other else, return for informed
 // typs.
-func (s *DB) EnabledAfterScanCallback(typs ...interface{}) (ok bool) {
+func (s *DB) IsEnabledAfterScanCallback(typs ...interface{}) (ok bool) {
 	key := "gorm:disable_after_scan"
 
 	if v, ok := s.values[key]; ok {

--- a/methodcallback.go
+++ b/methodcallback.go
@@ -106,7 +106,7 @@ func (registrator *StructFieldMethodCallbacksRegistrator) DisableFieldType(typs 
 }
 
 // Return if all callbacks for field type is enabled
-func (registrator *StructFieldMethodCallbacksRegistrator) EnabledFieldType(typ interface{}) bool {
+func (registrator *StructFieldMethodCallbacksRegistrator) IsEnabledFieldType(typ interface{}) bool {
 	if enabled, ok := registrator.FieldTypes.Get(typ); ok {
 		return enabled
 	}

--- a/methodcallback.go
+++ b/methodcallback.go
@@ -1,0 +1,92 @@
+package gorm
+
+import (
+	"reflect"
+	"fmt"
+)
+
+var interfaceType = reflect.TypeOf(func(a interface{}) {}).In(0)
+var methodPtrType = reflect.PtrTo(reflect.TypeOf(Method{}))
+
+type StructFieldMethodCallbacksRegistrator struct {
+	Callbacks map[string]reflect.Value
+}
+
+func (registrator *StructFieldMethodCallbacksRegistrator) Register(methodName string, caller interface{}) error {
+	value := reflect.ValueOf(caller)
+
+	if value.Kind() != reflect.Func {
+		return fmt.Errorf("Caller of method %q isn't a function.", methodName)
+	}
+
+	if value.Type().NumIn() < 2 {
+		return fmt.Errorf("The caller function %v for method %q require two args. Example: func(methodInfo *gorm.Method, method interface{}).",
+			value.Type(), methodName)
+	}
+
+	if value.Type().In(0) != methodPtrType {
+		return fmt.Errorf("First arg of caller %v for method %q isn't a %v type.", value.Type(), methodName, methodPtrType)
+	}
+
+	if value.Type().In(1) != interfaceType {
+		return fmt.Errorf("Second arg of caller %v for method %q isn't a interface{} type.", value.Type(), methodName)
+	}
+
+	registrator.Callbacks[methodName] = value
+	return nil
+}
+
+func (registrator *StructFieldMethodCallbacksRegistrator) RegisterMany(items ...map[string]interface{}) error {
+	for i, m := range items {
+		for methodName, callback := range m {
+			err := registrator.Register(methodName, callback)
+			if err != nil {
+				return fmt.Errorf("Register arg[%v][%q] failed: %v", i, methodName, err)
+			}
+		}
+	}
+	return nil
+}
+
+func NewStructFieldMethodCallbacksRegistrator() *StructFieldMethodCallbacksRegistrator {
+	return &StructFieldMethodCallbacksRegistrator{make(map[string]reflect.Value)}
+}
+
+func AfterScanMethodCallback(methodInfo *Method, method interface{}, field *Field, scope *Scope) {
+	switch method := method.(type) {
+	case func():
+		method()
+	case func(*Scope):
+		method(scope)
+	case func(*Scope, *Field):
+		method(scope, field)
+	case func(*DB, *Field):
+		newDB := scope.NewDB()
+		method(newDB, field)
+		scope.Err(newDB.Error)
+	case func() error:
+		scope.Err(method())
+	case func(*Scope) error:
+		scope.Err(method(scope))
+	case func(*Scope, *Field) error:
+		scope.Err(method(scope, field))
+	case func(*DB) error:
+		newDB := scope.NewDB()
+		scope.Err(method(newDB))
+		scope.Err(newDB.Error)
+	default:
+		scope.Err(fmt.Errorf("Invalid AfterScan method callback %v of type %v", reflect.ValueOf(method).Type(), field.Struct.Type))
+	}
+}
+
+// StructFieldMethodCallbacks is a default registrator for model fields callbacks where the field type is a struct
+// and have a callback method.
+// Default methods callbacks:
+// AfterScan: Call method `AfterScanMethodCallback` after scan field from sql row.
+var StructFieldMethodCallbacks = NewStructFieldMethodCallbacksRegistrator()
+
+func init() {
+	checkOrPanic(StructFieldMethodCallbacks.RegisterMany(map[string]interface{}{
+		"AfterScan": AfterScanMethodCallback,
+	}))
+}

--- a/methodcallback_test.go
+++ b/methodcallback_test.go
@@ -10,7 +10,7 @@ func init() {
 
 func ExampleStructFieldMethodCallbacksRegistrator_DisableFieldType() {
 	fmt.Println(`
-if registrator.EnabledFieldType(&Media{}) {
+if registrator.IsEnabledFieldType(&Media{}) {
 	registrator.DisableFieldType(&Media{})
 }
 `)
@@ -18,7 +18,7 @@ if registrator.EnabledFieldType(&Media{}) {
 
 func ExampleStructFieldMethodCallbacksRegistrator_EnabledFieldType() {
 	fmt.Println(`
-if !registrator.EnabledFieldType(&Media{}) {
+if !registrator.IsEnabledFieldType(&Media{}) {
 	println("not enabled")
 }
 `)
@@ -26,7 +26,7 @@ if !registrator.EnabledFieldType(&Media{}) {
 
 func ExampleStructFieldMethodCallbacksRegistrator_EnableFieldType() {
 	fmt.Println(`
-if !registrator.EnabledFieldType(&Media{}) {
+if !registrator.IsEnabledFieldType(&Media{}) {
 	registrator.EnableFieldType(&Media{})
 }
 `)

--- a/methodcallback_test.go
+++ b/methodcallback_test.go
@@ -9,27 +9,21 @@ func init() {
 }
 
 func ExampleStructFieldMethodCallbacksRegistrator_DisableFieldType() {
-	fmt.Println(`
-if registrator.IsEnabledFieldType(&Media{}) {
+	fmt.Println(`if registrator.IsEnabledFieldType(&Media{}) {
 	registrator.DisableFieldType(&Media{})
-}
-`)
+}`)
 }
 
 func ExampleStructFieldMethodCallbacksRegistrator_EnabledFieldType() {
-	fmt.Println(`
-if !registrator.IsEnabledFieldType(&Media{}) {
+	fmt.Println(`if !registrator.IsEnabledFieldType(&Media{}) {
 	println("not enabled")
-}
-`)
+}`)
 }
 
 func ExampleStructFieldMethodCallbacksRegistrator_EnableFieldType() {
-	fmt.Println(`
-if !registrator.IsEnabledFieldType(&Media{}) {
+	fmt.Println(`if !registrator.IsEnabledFieldType(&Media{}) {
 	registrator.EnableFieldType(&Media{})
-}
-`)
+}`)
 }
 
 func ExampleStructFieldMethodCallbacksRegistrator_RegisteredFieldType() {

--- a/methodcallback_test.go
+++ b/methodcallback_test.go
@@ -1,16 +1,59 @@
 package gorm_test
 
-import "fmt"
-
-func ExampleAfterScanMethodCallback() {
-	fmt.Println(`package main
-
 import (
 	"fmt"
+)
+
+func init() {
+
+}
+
+func ExampleStructFieldMethodCallbacksRegistrator_DisableFieldType() {
+	fmt.Println(`
+if registrator.EnabledFieldType(&Media{}) {
+	registrator.DisableFieldType(&Media{})
+}
+`)
+}
+
+func ExampleStructFieldMethodCallbacksRegistrator_EnabledFieldType() {
+	fmt.Println(`
+if !registrator.EnabledFieldType(&Media{}) {
+	println("not enabled")
+}
+`)
+}
+
+func ExampleStructFieldMethodCallbacksRegistrator_EnableFieldType() {
+	fmt.Println(`
+if !registrator.EnabledFieldType(&Media{}) {
+	registrator.EnableFieldType(&Media{})
+}
+`)
+}
+
+func ExampleStructFieldMethodCallbacksRegistrator_RegisteredFieldType() {
+	fmt.Println(`
+if registrator.RegisteredFieldType(&Media{}) {
+	println("not registered")
+}`)
+}
+
+func ExampleStructFieldMethodCallbacksRegistrator_RegisterFieldType() {
+	fmt.Println("registrator.RegisterFieldType(&Media{})")
+}
+
+func ExampleAfterScanMethodCallback() {
+	println(`
+package main
+
+import (
 	"reflect"
 	"github.com/jinzhu/gorm"
 	"database/sql/driver"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"strconv"
+	"strings"
 )
 
 type Media struct {
@@ -45,7 +88,8 @@ func (image *Media) AfterScan(scope *gorm.Scope, field *gorm.Field) {
 }
 
 func (image *Media) URL() string {
-	return fmt.Sprintf("%v/%v/%v/%v/%v", *image.baseUrl, image.modelType.Name(), image.model.GetID(), *image.fieldName, image.Name)
+	return strings.Join([]string{*image.baseUrl, image.modelType.Name(), strconv.Itoa(image.model.GetID()),
+		*image.fieldName, image.Name}, "/")
 }
 
 type User struct {
@@ -58,10 +102,14 @@ func (user *User) GetID() int {
 }
 
 func main() {
+	// register media type
+	gorm.StructFieldMethodCallbacks.RegisterFieldType(&Media{})
+
 	db, err := gorm.Open("sqlite3", "db.db")
 	if err != nil {
 		panic(err)
 	}
+
 	db.AutoMigrate(&User{})
 
 	baseUrl := "http://example.com/media"
@@ -79,6 +127,7 @@ func main() {
 		panic(db_.Error)
 	}
 
-	fmt.Println(model.MainImage.URL())
-}`)
+	println("Media URL:", model.MainImage.URL())
+}
+`)
 }

--- a/methodcallback_test.go
+++ b/methodcallback_test.go
@@ -1,0 +1,84 @@
+package gorm_test
+
+import "fmt"
+
+func ExampleAfterScanMethodCallback() {
+	fmt.Println(`package main
+
+import (
+	"fmt"
+	"reflect"
+	"github.com/jinzhu/gorm"
+	"database/sql/driver"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+type Media struct {
+	Name      string
+	baseUrl   *string
+	modelType reflect.Type
+	model interface {
+		GetID() int
+	}
+	fieldName *string
+}
+
+func (image *Media) Scan(value interface{}) error {
+	image.Name = string(value.([]byte))
+	return nil
+}
+
+func (image *Media) Value() (driver.Value, error) {
+	return image.Name, nil
+}
+
+func (image *Media) AfterScan(scope *gorm.Scope, field *gorm.Field) {
+	image.fieldName, image.model = &field.StructField.Name, scope.Value.(interface {
+		GetID() int
+	})
+	baseUrl, _ := scope.DB().Get("base_url")
+	image.baseUrl = baseUrl.(*string)
+	image.modelType = reflect.TypeOf(scope.Value)
+	for image.modelType.Kind() == reflect.Ptr {
+		image.modelType = image.modelType.Elem()
+	}
+}
+
+func (image *Media) URL() string {
+	return fmt.Sprintf("%v/%v/%v/%v/%v", *image.baseUrl, image.modelType.Name(), image.model.GetID(), *image.fieldName, image.Name)
+}
+
+type User struct {
+	ID        int
+	MainImage Media
+}
+
+func (user *User) GetID() int {
+	return user.ID
+}
+
+func main() {
+	db, err := gorm.Open("sqlite3", "db.db")
+	if err != nil {
+		panic(err)
+	}
+	db.AutoMigrate(&User{})
+
+	baseUrl := "http://example.com/media"
+	db = db.Set("base_url", &baseUrl)
+
+	var model User
+	db_ := db.Where("id = ?", 1).First(&model)
+	if db_.RecordNotFound() {
+		db.Save(&User{MainImage: Media{Name: "picture.jpg"}})
+		err = db.Where("id = ?", 1).First(&model).Error
+		if err != nil {
+			panic(err)
+		}
+	} else if db_.Error != nil {
+		panic(db_.Error)
+	}
+
+	fmt.Println(model.MainImage.URL())
+}`)
+}

--- a/migration_test.go
+++ b/migration_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+func init()  {
+	gorm.StructFieldMethodCallbacks.RegisterFieldType(&AfterScanField{}, &AfterScanFieldPtr{}, &InvalidAfterScanField{})
+}
+
 type User struct {
 	Id                int64
 	Age               int64

--- a/model_struct.go
+++ b/model_struct.go
@@ -66,6 +66,15 @@ func (s *ModelStruct) TableName(db *DB) string {
 	return DefaultTableNameHandler(db, s.defaultTableName)
 }
 
+type StructFieldMethodCallback struct {
+	Method
+	Caller reflect.Value
+}
+
+func (s StructFieldMethodCallback) Call(object reflect.Value, in []reflect.Value) {
+	s.Caller.Call(append([]reflect.Value{reflect.ValueOf(&s.Method), s.ObjectMethod(object)}, in...))
+}
+
 // StructField model field's struct definition
 type StructField struct {
 	DBName          string
@@ -81,6 +90,19 @@ type StructField struct {
 	Struct          reflect.StructField
 	IsForeignKey    bool
 	Relationship    *Relationship
+	MethodCallbacks map[string]StructFieldMethodCallback
+}
+
+// Call the method callback if exists by name.
+func (structField *StructField) CallMethodCallbackArgs(name string, object reflect.Value, in []reflect.Value) {
+	if callback, ok := structField.MethodCallbacks[name]; ok {
+		callback.Call(object, in)
+	}
+}
+
+// Call the method callback if exists by name. the
+func (structField *StructField) CallMethodCallback(name string, object reflect.Value, in ...reflect.Value) {
+	structField.CallMethodCallbackArgs(name, object, in)
 }
 
 func (structField *StructField) clone() *StructField {
@@ -97,6 +119,7 @@ func (structField *StructField) clone() *StructField {
 		TagSettings:     map[string]string{},
 		Struct:          structField.Struct,
 		IsForeignKey:    structField.IsForeignKey,
+		MethodCallbacks: structField.MethodCallbacks,
 	}
 
 	if structField.Relationship != nil {
@@ -579,6 +602,14 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 						}(field)
 					default:
 						field.IsNormal = true
+					}
+				}
+
+				field.MethodCallbacks = make(map[string]StructFieldMethodCallback)
+
+				for callbackName, caller := range StructFieldMethodCallbacks.Callbacks {
+					if callbackMethod := MethodByName(indirectType, callbackName); callbackMethod.valid {
+						field.MethodCallbacks[callbackName] = StructFieldMethodCallback{callbackMethod, caller}
 					}
 				}
 			}

--- a/model_struct.go
+++ b/model_struct.go
@@ -605,6 +605,7 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 					}
 				}
 
+				// register method callbacks now for improve performance
 				field.MethodCallbacks = make(map[string]StructFieldMethodCallback)
 
 				for callbackName, caller := range StructFieldMethodCallbacks.Callbacks {

--- a/scope.go
+++ b/scope.go
@@ -476,11 +476,11 @@ func (scope *Scope) quoteIfPossible(str string) string {
 // call after field method callbacks
 func (scope *Scope) afterScanCallback(scannerFields map[int]*Field, disableScanField map[int]bool) {
 	if !scope.HasError() && scope.Value != nil {
-		if scope.DB().EnabledAfterScanCallback(scope.Value) {
+		if scope.DB().IsEnabledAfterScanCallback(scope.Value) {
 			scopeValue := reflect.ValueOf(scope)
 			for index, field := range scannerFields {
 				// if not is nill and if calbacks enabled for field type
-				if StructFieldMethodCallbacks.EnabledFieldType(field.Field.Type()) {
+				if StructFieldMethodCallbacks.IsEnabledFieldType(field.Field.Type()) {
 					// not disabled on scan
 					if _, ok := disableScanField[index]; !ok {
 						if !isNil(field.Field) {

--- a/scope.go
+++ b/scope.go
@@ -475,16 +475,18 @@ func (scope *Scope) quoteIfPossible(str string) string {
 
 // call after field method callbacks
 func (scope *Scope) afterScanCallback(scannerFields map[int]*Field, disableScanField map[int]bool) {
-	if !scope.HasError() {
+	if !scope.HasError() && scope.Value != nil {
 		if scope.DB().EnabledAfterScanCallback(scope.Value) {
 			scopeValue := reflect.ValueOf(scope)
 			for index, field := range scannerFields {
-				// if calbacks enabled for field type
+				// if not is nill and if calbacks enabled for field type
 				if StructFieldMethodCallbacks.EnabledFieldType(field.Field.Type()) {
 					// not disabled on scan
 					if _, ok := disableScanField[index]; !ok {
-						reflectValue := field.Field.Addr()
-						field.CallMethodCallback("AfterScan", reflectValue, scopeValue)
+						if !isNil(field.Field) {
+							reflectValue := field.Field.Addr()
+							field.CallMethodCallback("AfterScan", reflectValue, scopeValue)
+						}
 					}
 				}
 			}

--- a/scope_test.go
+++ b/scope_test.go
@@ -127,20 +127,16 @@ func TestAfterFieldScanDisableCallback(t *testing.T) {
 		DB := DB.DisableAfterScanCallback(typs...)
 		var model2 WithFieldAfterScanCallback
 		if err := DB.Where("id = ?", model.ID).First(&model2).Error; err != nil {
-			t.Errorf("%q: No error should happen when querying WithFieldAfterScanCallback with valuer, but got %v", len(typs), err)
+			t.Errorf("%v: No error should happen when querying WithFieldAfterScanCallback with valuer, but got %v", len(typs), err)
 		}
 
-		dotest := func(i int, value string, field AfterScanFieldInterface) {
+		dotest := func(i int, field AfterScanFieldInterface) {
 			if !field.CalledFieldIsNill() {
-				t.Errorf("%q: Expected Name%v.calledField is not nil", len(typs), i)
-			}
-
-			if !field.CalledScopeIsNill() {
-				t.Errorf("%q: Expected Name%v.calledScope is not nil", len(typs), i)
+				t.Errorf("%v: Expected Name%v.calledField is nil", len(typs), i)
 			}
 		}
 
-		dotest(1, model.Name1.data, model2.Name1)
+		dotest(1, model2.Name1)
 	}
 
 	run()

--- a/utils.go
+++ b/utils.go
@@ -135,6 +135,73 @@ func indirect(reflectValue reflect.Value) reflect.Value {
 	return reflectValue
 }
 
+type Method struct {
+	index int
+	name  string
+	ptr   bool
+	valid bool
+}
+
+func (m Method) Index() int {
+	return m.index
+}
+
+func (m Method) Name() string {
+	return m.name
+}
+
+func (m Method) Ptr() bool {
+	return m.ptr
+}
+
+func (m Method) Valid() bool {
+	return m.valid
+}
+
+func (m Method) TypeMethod(typ reflect.Type) reflect.Method {
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	if m.ptr {
+		typ = reflect.PtrTo(typ)
+	}
+	return typ.Method(m.index)
+}
+
+func (m Method) ObjectMethod(object reflect.Value) reflect.Value {
+	object = indirect(object)
+	if m.ptr {
+		object = object.Addr()
+	}
+	return object.Method(m.index)
+}
+
+func MethodByName(typ reflect.Type, name string) (m Method) {
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	if typ.Kind() != reflect.Struct {
+		return
+	}
+
+	if method, ok := typ.MethodByName(name); ok {
+		m.index = method.Index
+		m.name = name
+		m.valid = true
+		return
+	}
+
+	if method, ok := reflect.PtrTo(typ).MethodByName(name); ok {
+		m.index = method.Index
+		m.name = name
+		m.ptr = true
+		m.valid = true
+	}
+
+	return
+}
+
 func toQueryMarks(primaryValues [][]interface{}) string {
 	var results []string
 
@@ -282,4 +349,10 @@ func addExtraSpaceIfExist(str string) string {
 		return " " + str
 	}
 	return ""
+}
+
+func checkOrPanic(err error) {
+	if err != nil {
+		panic(err)
+	}
 }

--- a/utils.go
+++ b/utils.go
@@ -135,6 +135,18 @@ func indirect(reflectValue reflect.Value) reflect.Value {
 	return reflectValue
 }
 
+func indirectType(reflectType reflect.Type) reflect.Type {
+	for reflectType.Kind() == reflect.Ptr {
+		reflectType = reflectType.Elem()
+	}
+	return reflectType
+}
+
+func ptrToType(reflectType reflect.Type) reflect.Type {
+	reflectType = indirectType(reflectType)
+	return reflect.PtrTo(reflectType)
+}
+
 type Method struct {
 	index int
 	name  string

--- a/utils.go
+++ b/utils.go
@@ -368,3 +368,14 @@ func checkOrPanic(err error) {
 		panic(err)
 	}
 }
+
+// check if value is nil
+func isNil(value reflect.Value) bool {
+	if value.Kind() != reflect.Ptr {
+		return false
+	}
+	if value.Pointer() == 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

these changes let you call the "AfterScan" method of a field after the "Scope.scan" called. This supplies fields that need context data coming from the scope, such as to expose the URL of a media according to the Request. See tests and samples for more details.
