### PR TITLE
Do not panic if Begin().Error was ignored

### DIFF
--- a/main.go
+++ b/main.go
@@ -491,7 +491,8 @@ func (s *DB) Begin() *DB {
 
 // Commit commit a transaction
 func (s *DB) Commit() *DB {
-	if db, ok := s.db.(sqlTx); ok && db != nil {
+	var emptySQLTx *sql.Tx
+	if db, ok := s.db.(sqlTx); ok && db != nil && db != emptySQLTx {
 		s.AddError(db.Commit())
 	} else {
 		s.AddError(ErrInvalidTransaction)


### PR DESCRIPTION
gorm is affected by a whole class of bugs due to the (in)famous [nil interface comparison](https://golang.org/doc/faq#nil_error) problem.

# Problem

If the developer does not check for `.Error` after calling `.Begin()`, then a panic will be triggered when calling `.Commit()` after a (silently) failed `Begin()`. It would be best that all gorm APIs returned an error as last parameter as normal Go code does, but that is another topic.

Code that will trigger the panic in case of `Begin()` failure:

```
    var db *gorm.DB
    // ... initialise db ...

    tx := db.Begin()
    // NOTICE here how no error is checked

    // panic will always happen here when `Begin()` failed before
    tx.Commit()
```

## Example of the generated panic
```
2018/04/03 03:07:22 http: panic serving 10.212.4.0:51123: runtime error: invalid memory address or nil pointer dereference
goroutine 940684 [running]:
net/http.(*conn).serve.func1(0xc4201be820)
	/usr/local/go/src/net/http/server.go:1726 +0xd0
panic(0x9f4c20, 0xf098a0)
	/usr/local/go/src/runtime/panic.go:505 +0x229
database/sql.(*Tx).Commit(0x0, 0x7f2734d38960, 0x0)
	/usr/local/go/src/database/sql/sql.go:1921 +0x26
example/package/vendor/github.com/jinzhu/gorm.(*DB).Commit(0xc420e4e1b0, 0x995e20)
	/srv/src/example/package/vendor/github.com/jinzhu/gorm/main.go:479 +0xa4
example/package/model.Subordinates(0xc420f5c3ee, 0x1, 0xc420068e80, 0xc420ea32d0, 0x0)
	/srv/src/example/package/model/model.go:123 +0x1b3
[...]
net/http.(*conn).serve(0xc4201be820, 0xb30580, 0xc420aa9b40)
	/usr/local/go/src/net/http/server.go:1830 +0x651
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2795 +0x27b
```

# Proposed solution
To prevent panics at runtime, I suggest an extra check being performed with the nil interface that is going to be found on the struct after a failed `.Begin()`.

# Play-able example:

See this playground: https://play.golang.org/p/TVR2lIMsapm

Change the constant `useFixedCommit` to see the fixed (from this PR) vs current behavior.

# Checklist
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [ ] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.