### PR TITLE
fix scope.removeForeignKey method

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -1215,7 +1215,7 @@ func (scope *Scope) addForeignKey(field string, dest string, onDelete string, on
 }
 
 func (scope *Scope) removeForeignKey(field string, dest string) {
-	keyName := scope.Dialect().BuildKeyName(scope.TableName(), field, dest)
+	keyName := scope.Dialect().BuildKeyName(scope.TableName(), field, dest, "foreign")
 
 	if !scope.Dialect().HasForeignKey(scope.TableName(), keyName) {
 		return


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [✅] Do only one thing
- [✅] No API-breaking changes
- [✅] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
scope.removeForeignKey doesn't *actually* remove a foreign key because scope.addForeignKey passed a parameter to BuildKeyName that remove didn't. I have since remedied this