### PR TITLE
add simple input validation on gorm.Open function

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,8 @@ func Open(dialect string, args ...interface{}) (db *DB, err error) {
 		dbSQL, err = sql.Open(driver, source)
 	case SQLCommon:
 		dbSQL = value
+	default:
+		return nil, fmt.Errorf("invalid database source: %v is not a valid type", value)
 	}
 
 	db = &DB{

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +78,22 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	db.DB().SetMaxIdleConns(10)
 
 	return
+}
+
+func TestOpen_ReturnsError_WithBadArgs(t *testing.T) {
+	stringRef := "foo"
+	testCases := []interface{}{42, time.Now(), &stringRef}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			_, err := gorm.Open("postgresql", tc)
+			if err == nil {
+				t.Error("Should got error with invalid database source")
+			}
+			if !strings.HasPrefix(err.Error(), "invalid database source:") {
+				t.Errorf("Should got error starting with \"invalid database source:\", but got %q", err.Error())
+			}
+		})
+	}
 }
 
 func TestStringPrimaryKey(t *testing.T) {


### PR DESCRIPTION
Simply check if the passed-in database source meets the expected types
and, if not, early return with error.

This caused me to lose nearly an hour trying to debug why I was getting nil pointer errors, only to find out I was passing in a string pointer instead of a string. A simple input validation here would have errored me out early and I could have discovered my dumb mistake much earlier :)