### PR TITLE
Adding GetDialect method to fetch existing gorm.Dialect implementations

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -72,6 +72,12 @@ func RegisterDialect(name string, dialect Dialect) {
 	dialectsMap[name] = dialect
 }
 
+// GetDialect gets the dialect for the specified dialect name
+func GetDialect(name string) (dialect Dialect, ok bool) {
+	dialect, ok = dialectsMap[name]
+	return
+}
+
 // ParseFieldStructForDialect get field's sql data type
 var ParseFieldStructForDialect = func(field *StructField, dialect Dialect) (fieldValue reflect.Value, sqlType string, size int, additionalType string) {
 	// Get redirected field type


### PR DESCRIPTION
- [x] Do only one thing
- [x] No API-breaking changes
- [ ] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

This PR adds a GetDialect function that returns existing dialects.

We need the ability to connect to a database through an SSH tunnel while using gorm. This can be accomplished like so: https://gist.github.com/vinzenz/7b6b1bf8d0c2b2b1e0d69a15ba9f02c7 

The problem occurs here:
```go
sql.Register("postgres+ssh", &ViaSSHDialer{sshcon})
db, err = gorm.Open("postgres+ssh", options.ContentDBDSN)
```

The database connects just fine buts runs under compatibility mode and you get the following warning message:
```
`postgres+ssh` is not officially supported, running under compatibility mode.
```

Running under compatibility mode breaks any kind if postgres functionality. With this PR we can do the following:

```go
dialect, ok := gorm.GetDialect("postgres")
if !ok {
	// Handle error..
	return
}

gorm.RegisterDialect("postgres+ssh", dialect)
```