### PR TITLE
Do not panic if Begin().Error was ignored (#1830)

### DIFF
--- a/main.go
+++ b/main.go
@@ -504,7 +504,8 @@ func (s *DB) Commit() *DB {
 
 // Rollback rollback a transaction
 func (s *DB) Rollback() *DB {
-	if db, ok := s.db.(sqlTx); ok && db != nil {
+	var emptySQLTx *sql.Tx
+	if db, ok := s.db.(sqlTx); ok && db != nil && db != emptySQLTx {
 		s.AddError(db.Rollback())
 	} else {
 		s.AddError(ErrInvalidTransaction)


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

Fixes issue #1830 when db `Rollback()`

```
2018/05/04 11:35:02 http: panic serving 127.0.0.1:51133: runtime error: invalid memory address or nil pointer dereference
goroutine 257 [running]:
net/http.(*conn).serve.func1(0xc42027a640)
        .../dev/go/src/net/http/server.go:1726 +0xd0
panic(0x14600e0, 0x17842e0)
        .../dev/go/src/runtime/panic.go:505 +0x229
database/sql.(*Tx).rollback(0x0, 0x14c5500, 0x1, 0x1a96480)
        .../dev/go/src/database/sql/sql.go:1944 +0x2d
database/sql.(*Tx).Rollback(0x0, 0x1a91408, 0x0)
        .../dev/go/src/database/sql/sql.go:1963 +0x30
github.com/jinzhu/gorm.(*DB).Rollback(0xc4206ee1b0, 0x1530670)
        .../dev/app/src/github.com/jinzhu/gorm/main.go:506 +0xa4
```