### PR TITLE
included actual sql query to discover if foreign key with the same na…

### DIFF
--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -130,7 +130,14 @@ func (s mssql) RemoveIndex(tableName string, indexName string) error {
 }
 
 func (s mssql) HasForeignKey(tableName string, foreignKeyName string) bool {
-	return false
+	var count int
+	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
+	s.db.QueryRow(`SELECT count(*) 
+	FROM sys.foreign_keys as F inner join sys.tables as T on F.parent_object_id=T.object_id 
+		inner join information_schema.tables as I on I.TABLE_NAME = T.name 
+	WHERE F.name = ? 
+		AND T.Name = ? AND I.TABLE_CATALOG = ?;`, foreignKeyName, tableName, currentDatabase).Scan(&count)
+	return count > 0
 }
 
 func (s mssql) HasTable(tableName string) bool {


### PR DESCRIPTION
…me exists in a specific table of the database in use

- [] Just one minor fix, adding the query to discover if foreign key exists for mssql dialect
- [] No API-breaking changes
- [] Did not add any test as there where no existing wither for the other dialects, but I can add some if you want

### What did this pull request do?
Added an sql query to change the empty HasFoerignKey function in mssql dialect