### PR TITLE
Wrapping field value with DBMS functions on insert/update

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -65,13 +65,13 @@ func createCallback(scope *Scope) {
 						scope.InstanceSet("gorm:blank_columns_with_default_value", blankColumnsWithDefaultValue)
 					} else if !field.IsPrimaryKey || !field.IsBlank {
 						columns = append(columns, scope.Quote(field.DBName))
-						placeholders = append(placeholders, scope.AddToVars(field.Field.Interface()))
+						placeholders = append(placeholders, scope.WrapPlaceholder(field, scope.AddToVars(field.Field.Interface())))
 					}
 				} else if field.Relationship != nil && field.Relationship.Kind == "belongs_to" {
 					for _, foreignKey := range field.Relationship.ForeignDBNames {
 						if foreignField, ok := scope.FieldByName(foreignKey); ok && !scope.changeableField(foreignField) {
 							columns = append(columns, scope.Quote(foreignField.DBName))
-							placeholders = append(placeholders, scope.AddToVars(foreignField.Field.Interface()))
+							placeholders = append(placeholders, scope.WrapPlaceholder(foreignField, scope.AddToVars(foreignField.Field.Interface())))
 						}
 					}
 				}

--- a/callback_update.go
+++ b/callback_update.go
@@ -76,12 +76,12 @@ func updateCallback(scope *Scope) {
 			for _, field := range scope.Fields() {
 				if scope.changeableField(field) {
 					if !field.IsPrimaryKey && field.IsNormal {
-						sqls = append(sqls, fmt.Sprintf("%v = %v", scope.Quote(field.DBName), scope.AddToVars(field.Field.Interface())))
+						sqls = append(sqls, fmt.Sprintf("%v = %v", scope.Quote(field.DBName), scope.WrapPlaceholder(field, scope.AddToVars(field.Field.Interface()))))
 					} else if relationship := field.Relationship; relationship != nil && relationship.Kind == "belongs_to" {
 						for _, foreignKey := range relationship.ForeignDBNames {
 							if foreignField, ok := scope.FieldByName(foreignKey); ok && !scope.changeableField(foreignField) {
 								sqls = append(sqls,
-									fmt.Sprintf("%v = %v", scope.Quote(foreignField.DBName), scope.AddToVars(foreignField.Field.Interface())))
+									fmt.Sprintf("%v = %v", scope.Quote(foreignField.DBName), scope.WrapPlaceholder(foreignField, scope.AddToVars(foreignField.Field.Interface()))))
 							}
 						}
 					}

--- a/scope.go
+++ b/scope.go
@@ -283,7 +283,7 @@ func (scope *Scope) WrapPlaceholder(field *Field, placeholder string) string {
 		return placeholder
 	} else {
 		// Wrap a placeholder into wrapper
-		return strings.Replace(wr, "?", placeholder, 1)
+		return strings.Replace(wr, "?", placeholder, -1)
 	}
 }
 

--- a/scope.go
+++ b/scope.go
@@ -277,6 +277,16 @@ func (scope *Scope) AddToVars(value interface{}) string {
 	return scope.Dialect().BindVar(len(scope.SQLVars))
 }
 
+// WrapPlaceholder returns a field's value placeholder wrapped into wrapper function
+func (scope *Scope) WrapPlaceholder(field *Field, placeholder string) string {
+	if wr, exists := field.TagSettings["WRAPPER"]; !exists || len(wr) == 0 {
+		return placeholder
+	} else {
+		// Wrap a placeholder into wrapper
+		return strings.Replace(wr, "?", placeholder, 1)
+	}
+}
+
 // SelectAttrs return selected attributes
 func (scope *Scope) SelectAttrs() []string {
 	if scope.selectAttrs == nil {


### PR DESCRIPTION
**New feature:**
Allow using user-defined field value wrapper functions on insert/update queries **avoiding raw SQL**.
**_Why avoiding raw SQL?_**
If you want to minimize your code with a single db.save() operation, especially when you have a lot of nesting related objects, you can just set a wrapper tag instead of moving to raw SQL.

Usage:
```
type Object struct {
    ...
    field1 string `gorm:"wrapper:ST_GeomFromText(?)"`
    field2 string `gorm:"wrapper:UserFunc(?)"`
}
```

Use case:
1. Spatial functions. If you have geometry type fields but want to use WKT instead of WKB to write values into DB.
2. Date/string functions. If you want to perform extra actions on DBMS side (eg. extract only a part of value, transform a value etc.) to avoid in-app implementation.
3. User-defined DBMS functions to pre-process values.