### PR TITLE
Support only preloading 

### DIFF
--- a/callback_query.go
+++ b/callback_query.go
@@ -19,6 +19,10 @@ func queryCallback(scope *Scope) {
 		return
 	}
 
+	if _, skip := scope.InstanceGet("gorm:only_preload"); skip {
+		return
+	}
+
 	defer scope.trace(NowFunc())
 
 	var (

--- a/callback_query.go
+++ b/callback_query.go
@@ -18,7 +18,8 @@ func queryCallback(scope *Scope) {
 	if _, skip := scope.InstanceGet("gorm:skip_query_callback"); skip {
 		return
 	}
-
+	
+	//we are only preloading relations, dont touch base model
 	if _, skip := scope.InstanceGet("gorm:only_preload"); skip {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -311,6 +311,11 @@ func (s *DB) Find(out interface{}, where ...interface{}) *DB {
 	return s.NewScope(out).inlineCondition(where...).callCallbacks(s.parent.callbacks.queries).db
 }
 
+//Preloads preloads relations, don`t touch out
+func (s *DB) Preloads(out interface{}) *DB {
+	return s.NewScope(out).InstanceSet("gorm:only_preload", 1).callCallbacks(s.parent.callbacks.queries).db
+}
+
 // Scan scan value to a struct
 func (s *DB) Scan(dest interface{}) *DB {
 	return s.NewScope(s.Value).Set("gorm:query_destination", dest).callCallbacks(s.parent.callbacks.queries).db


### PR DESCRIPTION
Add function to only preload an already populated/initialized model. Very small and simple change. Using to preload simple fields of an model with custom sql on a performance-critical context.