### PR TITLE
Fix issue updating models with foreign key constraints

### DIFF
--- a/callback_update.go
+++ b/callback_update.go
@@ -76,7 +76,9 @@ func updateCallback(scope *Scope) {
 			for _, field := range scope.Fields() {
 				if scope.changeableField(field) {
 					if !field.IsPrimaryKey && field.IsNormal {
-						sqls = append(sqls, fmt.Sprintf("%v = %v", scope.Quote(field.DBName), scope.AddToVars(field.Field.Interface())))
+						if !field.IsBlank || !field.HasDefaultValue {
+							sqls = append(sqls, fmt.Sprintf("%v = %v", scope.Quote(field.DBName), scope.AddToVars(field.Field.Interface())))
+						}
 					} else if relationship := field.Relationship; relationship != nil && relationship.Kind == "belongs_to" {
 						for _, foreignKey := range relationship.ForeignDBNames {
 							if foreignField, ok := scope.FieldByName(foreignKey); ok && !scope.changeableField(foreignField) {

--- a/callback_update.go
+++ b/callback_update.go
@@ -76,7 +76,7 @@ func updateCallback(scope *Scope) {
 			for _, field := range scope.Fields() {
 				if scope.changeableField(field) {
 					if !field.IsPrimaryKey && field.IsNormal {
-						if !field.IsBlank || !field.HasDefaultValue {
+						if !field.IsForeignKey || !field.IsBlank || !field.HasDefaultValue {
 							sqls = append(sqls, fmt.Sprintf("%v = %v", scope.Quote(field.DBName), scope.AddToVars(field.Field.Interface())))
 						}
 					} else if relationship := field.Relationship; relationship != nil && relationship.Kind == "belongs_to" {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
We found an issue where Gorm was trying to write the zero value of a has_one foreign key into the table and when using actual database foreign keys, the value `0` was invalid. This pull request adds a check in the `updateCallback` to ensure the field being update is not a blank foreign key with a default value. In our case the has_one relationship has a default value of null in the event that the model does not have the child yet. 

All gorm tests pass and this makes it safe to use foreign keys with a default value of null. 