### PR TITLE
Adding Trace attribute Scope to store tracing info

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -24,6 +24,7 @@ type Scope struct {
 	skipLeft        bool
 	fields          *[]*Field
 	selectAttrs     *[]string
+	Trace           interface{}
 }
 
 // IndirectValue return scope's reflect value's indirect value


### PR DESCRIPTION
If we want to add opentrace or newrelic trace to gorm queries, application side we have to wrap every query with the trace function. This looks somewhat ugly.

We can use callbacks here. But the trace should be shared between before query callback function and after query callback function. Since scope is available to both fucntions, i am adding one more attribute to scope to store trace info.

Now we can start tracing in before callback and store that at Trace and we can end that trace in after callback function.
