### PR TITLE
Setting gorm:auto_preload to false now prevents preloading

### DIFF
--- a/callback_query_preload.go
+++ b/callback_query_preload.go
@@ -14,8 +14,14 @@ func preloadCallback(scope *Scope) {
 		return
 	}
 
-	if _, ok := scope.Get("gorm:auto_preload"); ok {
-		autoPreload(scope)
+	if ap, ok := scope.Get("gorm:auto_preload"); ok {
+		// If gorm:auto_preload IS NOT a bool then auto preload.
+		// Else if it IS a bool, use the value
+		if apb, ok := ap.(bool); !ok {
+			autoPreload(scope)
+		} else if apb {
+			autoPreload(scope)
+		}
 	}
 
 	if scope.Search.preload == nil || scope.HasError() {

--- a/preload_test.go
+++ b/preload_test.go
@@ -123,6 +123,31 @@ func TestAutoPreload(t *testing.T) {
 	}
 }
 
+func TestAutoPreloadFalseDoesntPreload(t *testing.T) {
+	user1 := getPreloadUser("auto_user1")
+	DB.Save(user1)
+
+	preloadDB := DB.Set("gorm:auto_preload", false).Where("role = ?", "Preload")
+	var user User
+	preloadDB.Find(&user)
+
+	if user.BillingAddress.Address1 != "" {
+		t.Error("AutoPreload was set to fasle, but still fetched data")
+	}
+
+	user2 := getPreloadUser("auto_user2")
+	DB.Save(user2)
+
+	var users []User
+	preloadDB.Find(&users)
+
+	for _, user := range users {
+		if user.BillingAddress.Address1 != "" {
+			t.Error("AutoPreload was set to fasle, but still fetched data")
+		}
+	}
+}
+
 func TestNestedPreload1(t *testing.T) {
 	type (
 		Level1 struct {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Currently if you set `gorm:auto_preload` to `false`, it still preloads data.  This PR makes it so that doesn't happen.