### PR TITLE
save_associations:true should store related item

### DIFF
--- a/callback_save.go
+++ b/callback_save.go
@@ -21,9 +21,7 @@ func saveAssociationCheck(scope *Scope, field *Field) (autoUpdate bool, autoCrea
 
 		if v, ok := value.(string); ok {
 			v = strings.ToLower(v)
-			if v == "false" || v != "skip" {
-				return false
-			}
+			return v == "true"
 		}
 
 		return true
@@ -36,9 +34,11 @@ func saveAssociationCheck(scope *Scope, field *Field) (autoUpdate bool, autoCrea
 			if value, ok := scope.Get("gorm:save_associations"); ok {
 				autoUpdate = checkTruth(value)
 				autoCreate = autoUpdate
+				saveReference = autoUpdate
 			} else if value, ok := field.TagSettings["SAVE_ASSOCIATIONS"]; ok {
 				autoUpdate = checkTruth(value)
 				autoCreate = autoUpdate
+				saveReference = autoUpdate
 			}
 
 			if value, ok := scope.Get("gorm:association_autoupdate"); ok {

--- a/migration_test.go
+++ b/migration_test.go
@@ -118,6 +118,14 @@ type Company struct {
 	Owner *User `sql:"-"`
 }
 
+type Place struct {
+	Id             int64
+	PlaceAddressId int
+	PlaceAddress   *Address `gorm:"save_associations:false"`
+	OwnerAddressId int
+	OwnerAddress   *Address `gorm:"save_associations:true"`
+}
+
 type EncryptedData []byte
 
 func (data *EncryptedData) Scan(value interface{}) error {
@@ -284,7 +292,7 @@ func runMigration() {
 		DB.Exec(fmt.Sprintf("drop table %v;", table))
 	}
 
-	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}}
+	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}, &Place{}}
 	for _, value := range values {
 		DB.DropTable(value)
 	}


### PR DESCRIPTION
Problem definition:

given models
```
type Address struct {
	ID        int
	Address1  string
}

type Place struct {
	Id             int64
	PlaceAddressId int
	PlaceAddress   *Address `gorm:"save_associations:false"`
	OwnerAddressId int
	OwnerAddress   *Address `gorm:"save_associations:true"`
}
```

When storing Place object with new OwnerAddress no Address created.
```
ownerAddress1 := &Address{Address1: "addr1"}
place := &Place{
  OwnerAddress: ownerAddress1,
}
db.Create(place)
// number of addresses in db == 0
// ownerAdress1.ID == 0
```

Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

### What did this pull request do?

Fix bug related to ignoring `save_associations:true|false` flag
