### PR TITLE
Fix scanning identical column names occurring >2 times

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -486,8 +486,10 @@ func (scope *Scope) scan(rows *sql.Rows, columns []string, fields []*Field) {
 		values[index] = &ignored
 
 		selectFields = fields
+		offset := 0
 		if idx, ok := selectedColumnsMap[column]; ok {
-			selectFields = selectFields[idx+1:]
+			offset = idx + 1
+			selectFields = selectFields[offset:]
 		}
 
 		for fieldIndex, field := range selectFields {
@@ -501,7 +503,7 @@ func (scope *Scope) scan(rows *sql.Rows, columns []string, fields []*Field) {
 					resetFields[index] = field
 				}
 
-				selectedColumnsMap[column] = fieldIndex
+				selectedColumnsMap[column] = offset + fieldIndex
 
 				if field.IsNormal {
 					break


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

Fix a bug in `Scope.scan` where fields with repeated names are not incorrectly skipped. Specifically, values in `selectedColumns` must be indexed relative to `fields`, not `selectFields`.

Add a test demonstrating how a SELECT query with three ID fields from a joined table can be used to populate a single struct with the correct values. (The test fails without this fix.)