### PR TITLE
rewrite if-else chain as switch statement

### DIFF
--- a/association.go
+++ b/association.go
@@ -267,15 +267,16 @@ func (association *Association) Count() int {
 		query        = scope.DB()
 	)
 
-	if relationship.Kind == "many_to_many" {
+	switch relationship.Kind {
+	case "many_to_many":
 		query = relationship.JoinTableHandler.JoinWith(relationship.JoinTableHandler, query, scope.Value)
-	} else if relationship.Kind == "has_many" || relationship.Kind == "has_one" {
+	case "has_many", "has_one":
 		primaryKeys := scope.getColumnAsArray(relationship.AssociationForeignFieldNames, scope.Value)
 		query = query.Where(
 			fmt.Sprintf("%v IN (%v)", toQueryCondition(scope, relationship.ForeignDBNames), toQueryMarks(primaryKeys)),
 			toQueryValues(primaryKeys)...,
 		)
-	} else if relationship.Kind == "belongs_to" {
+	case "belongs_to":
 		primaryKeys := scope.getColumnAsArray(relationship.ForeignFieldNames, scope.Value)
 		query = query.Where(
 			fmt.Sprintf("%v IN (%v)", toQueryCondition(scope, relationship.AssociationForeignDBNames), toQueryMarks(primaryKeys)),


### PR DESCRIPTION
From effective Go: https://golang.org/doc/effective_go.html#switch

> It's therefore possible—and idiomatic—to write an if-else-if-else chain as a switch.

