### PR TITLE
Fix Panic in test scenerio

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -40,7 +40,7 @@ func (s *ModelStruct) TableName(db *DB) string {
 			s.defaultTableName = tabler.TableName()
 		} else {
 			tableName := ToTableName(s.ModelType.Name())
-			if db == nil || !db.parent.singularTable {
+			if db == nil || (db.parent != nil && !db.parent.singularTable) {
 				tableName = inflection.Plural(tableName)
 			}
 			s.defaultTableName = tableName


### PR DESCRIPTION
I have found that there are times when testing that if I did not create the database through Open() it will not have the parent set and cause a panic when it hits this code path.

Make sure these boxes checked before submitting your pull request.

- [/] Do only one thing
- [/] No API-breaking changes
- [/] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
