### PR TITLE
Check valuer interface before scan value

### DIFF
--- a/field_test.go
+++ b/field_test.go
@@ -3,6 +3,7 @@ package gorm_test
 import (
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/jinzhu/gorm"
 )
 
@@ -45,5 +46,22 @@ func TestCalculateField(t *testing.T) {
 		t.Errorf("should find embedded field")
 	} else if _, ok := field.TagSettingsGet("NOT NULL"); !ok {
 		t.Errorf("should find embedded field's tag settings")
+	}
+}
+
+func TestFieldSet(t *testing.T) {
+	type TestFieldSetNullUUID struct {
+		NullUUID uuid.NullUUID
+	}
+	scope := DB.NewScope(&TestFieldSetNullUUID{})
+	field := scope.Fields()[0]
+	err := field.Set(uuid.FromStringOrNil("3034d44a-da03-11e8-b366-4a00070b9f00"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id, ok := field.Field.Addr().Interface().(*uuid.NullUUID); !ok {
+		t.Fatal()
+	} else if !id.Valid || id.UUID.String() != "3034d44a-da03-11e8-b366-4a00070b9f00" {
+		t.Fatal(id)
 	}
 }


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
convert via valuer interface before do scan.
Scan interface only accept int64, float64, bool, []byte, string,
time.Time or nil. When do scan, it's better to check whether the type
support valuer interface and do convert.