### PR TITLE
Argument that can be set on DB structure

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,26 @@ type DB struct {
 	callbacks     *Callback
 	dialect       Dialect
 	singularTable bool
+
+	// Arguments you can add to a db
+	arg interface{}
+}
+
+// SetArg allows you to set an application defined argument to
+// a DB object.
+func (db *DB) SetArg(i interface{}) {
+	db.arg = i
+}
+// Arg returns the application defined argument for the DB 
+// object.
+func (db *DB) Arg() interface{} {
+	if nil!=db.arg {
+		return db.arg
+	}
+	if nil!=db.parent && db.parent!=db {
+		return db.parent.Arg()
+	}
+	return nil
 }
 
 // Open initialize a new db connection, need to import driver first, e.g:
@@ -750,6 +770,7 @@ func (s *DB) GetErrors() []error {
 
 func (s *DB) clone() *DB {
 	db := &DB{
+		arg: 			   s.arg,
 		db:                s.db,
 		parent:            s.parent,
 		logger:            s.logger,


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
This PR adds a `SetArg(interface{})` and a `Arg() interface{}` method to a DB. The argument is a user-settable value that can be retrieved from the DB in the various callbacks, allowing a user to extend the DB class in their own code, and then access the extended class in the callbacks.

#### Rationale
I extend the *DB and create a transaction for each web request. I then do request-scoped caching for the request: for example, I will only use the ORM to lookup a user once during the request, and cache that user result: I do not want the cache globally scoped, because of cache eviction issues. However, in the various callbacks (AfterFind especially), I need access to the request-scoped cache, so scoping the cache to the transaction (the *DB) works perfectly. EXCEPT, when I am inside a callback, I no longer have access to the extended *DB class that contains my cache.
Using the `SetArg(interface{})` and `Arg() interface{}` methods, I can link my own class to the `*DB` and then retrieve this class inside the callbacks.
