### PR TITLE
Log adds context features

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -43,7 +43,6 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 			// duration
 			messages = append(messages, fmt.Sprintf(" \033[36;1m[%.2fms]\033[0m ", float64(values[2].(time.Duration).Nanoseconds()/1e4)/100.0))
 			// sql
-
 			for _, value := range values[4].([]interface{}) {
 				indirectValue := reflect.Indirect(reflect.ValueOf(value))
 				if indirectValue.IsValid() {
@@ -101,6 +100,7 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 
 type logger interface {
 	Print(v ...interface{})
+	CtxPrint(s *DB,v ...interface{})
 }
 
 // LogWriter log writer interface
@@ -116,4 +116,16 @@ type Logger struct {
 // Print format & print log
 func (logger Logger) Print(values ...interface{}) {
 	logger.Println(LogFormatter(values...)...)
+}
+
+// Print format & print log
+func (logger Logger) CtxPrint(s *DB,values ...interface{}) {
+	ctx,ok:=s.GetCtx()
+	if ok{
+		logMessage:=[]interface{}{}
+		logMessage=append(LogFormatter(values...), ctx)
+		logger.Println(logMessage...)
+	}else{
+		logger.Println(LogFormatter(values...)...)
+	}
 }

--- a/logger.go
+++ b/logger.go
@@ -118,7 +118,7 @@ func (logger Logger) Print(values ...interface{}) {
 	logger.Println(LogFormatter(values...)...)
 }
 
-// Print format & print log
+// CtxPrint format & print log
 func (logger Logger) CtxPrint(s *DB,values ...interface{}) {
 	ctx,ok:=s.GetCtx()
 	if ok{

--- a/logger_test.go
+++ b/logger_test.go
@@ -30,8 +30,8 @@ func TestLoggerCtx(t *testing.T) {
 
 		//Generating context information
 		unixTime := fmt.Sprint(time.Now().Unix())
-		traceId := fmt.Sprintf("%x", md5.Sum([]byte(unixTime)))
-		ctxInfo:= "\n[context] trace_id="+traceId
+		traceID := fmt.Sprintf("%x", md5.Sum([]byte(unixTime)))
+		ctxInfo:= "\n[context] trace_id="+traceID
 		builder := DB.SetCtx(ctxInfo)
 		if i > 5 {
 			builder = builder.Where("Age = ?", i)

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,54 @@
+package gorm_test
+
+import (
+	"testing"
+	"os"
+	"crypto/md5"
+	"fmt"
+	"time"
+	"github.com/jinzhu/gorm"
+	"log"
+)
+
+func TestLoggerCtx(t *testing.T) {
+	DB.SetLogger(gorm.Logger{log.New(os.Stdout, "\r\n", 0)})
+	if debug := os.Getenv("DEBUG"); debug == "true" {
+		DB.LogMode(true)
+	} else if debug == "false" {
+		DB.LogMode(false)
+	}
+
+	if logCtx := os.Getenv("LOGCTX"); logCtx == "true" {
+		DB.LogCtx(true)
+	} else if logCtx == "false" {
+		DB.LogCtx(false)
+	}
+
+	i := 0
+	for i < 10 {
+		i++
+
+		//Generating context information
+		unixTime := fmt.Sprint(time.Now().Unix())
+		traceId := fmt.Sprintf("%x", md5.Sum([]byte(unixTime)))
+		ctxInfo:= "\n[context] trace_id="+traceId
+		builder := DB.SetCtx(ctxInfo)
+		if i > 5 {
+			builder = builder.Where("Age = ?", i)
+		} else {
+			builder = builder.Where("Name = ?", i)
+		}
+
+		if builder.Find(&User{}).Error == nil {
+			t.Errorf("Should got error with invalid SQL")
+		}
+
+		//Verify context information
+		ctxTmp,_:=builder.GetCtx()
+		ctxInfo2,_:=ctxTmp.(string)
+		if ctxInfo!=ctxInfo2{
+			t.Fatal("get context error")
+		}
+	}
+}
+

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ type DB struct {
 	db                SQLCommon
 	blockGlobalUpdate bool
 	logMode           int
+	logCtx            int
 	logger            logger
 	search            *search
 	values            sync.Map
@@ -146,6 +147,30 @@ func (s *DB) LogMode(enable bool) *DB {
 		s.logMode = 1
 	}
 	return s
+}
+
+// LogMode set log ctx, `true` for get context when printing logs, `false` for no context, default, false
+func (s *DB) LogCtx(enable bool) *DB {
+	s.logCtx = 2
+	return s
+	fmt.Println(enable)
+	if enable {
+		s.logCtx = 2
+	} else {
+		s.logCtx = 1
+	}
+	return s
+}
+
+// Set query context
+func (s *DB) SetCtx(v interface{}) *DB {
+	s=s.Set("trace_context",v)
+	return s
+}
+
+// Get query context
+func (s *DB) GetCtx() (value interface{}, ok bool)  {
+	return s.Get("trace_context")
 }
 
 // BlockGlobalUpdate if true, generates an error on update/delete without where clause.
@@ -776,7 +801,11 @@ func (s *DB) clone() *DB {
 }
 
 func (s *DB) print(v ...interface{}) {
-	s.logger.Print(v...)
+	if s.logCtx == 2{
+		s.logger.CtxPrint(s, v...)
+	}else{
+		s.logger.Print(v...)
+	}
 }
 
 func (s *DB) log(v ...interface{}) {

--- a/main.go
+++ b/main.go
@@ -149,11 +149,8 @@ func (s *DB) LogMode(enable bool) *DB {
 	return s
 }
 
-// LogMode set log ctx, `true` for get context when printing logs, `false` for no context, default, false
+// LogCtx set log ctx, `true` for get context when printing logs, `false` for no context, default, false
 func (s *DB) LogCtx(enable bool) *DB {
-	s.logCtx = 2
-	return s
-	fmt.Println(enable)
 	if enable {
 		s.logCtx = 2
 	} else {
@@ -162,13 +159,13 @@ func (s *DB) LogCtx(enable bool) *DB {
 	return s
 }
 
-// Set query context
+// SetCtx set query context
 func (s *DB) SetCtx(v interface{}) *DB {
 	s=s.Set("trace_context",v)
 	return s
 }
 
-// Get query context
+// GetCtx Get query context
 func (s *DB) GetCtx() (value interface{}, ok bool)  {
 	return s.Get("trace_context")
 }


### PR DESCRIPTION
Log adds context features

If I want to set up a separate context context for a HTTP session request, You can use this feature.

### Testing steps
1. export DEBUG=true
2. export LOGCTX=true 
3. go test -v -run "TestLogger"