### PR TITLE
New feature, add CopyIn for postgres dialect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 documents
 _book
 .idea/workspace.xml
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 documents
 _book
+.idea/workspace.xml

--- a/main_test.go
+++ b/main_test.go
@@ -1059,6 +1059,61 @@ func TestBlockGlobalUpdate(t *testing.T) {
 	}
 }
 
+func TestDB_DataSource(t *testing.T) {
+	source := "user=gorm password=gorm DB.name=gorm port=9920 sslmode=disable"
+	db, er := gorm.Open("postgres", source)
+	if er != nil {
+		panic(fmt.Sprintf("No error should happen when connecting to test database, but got err=%+v", er))
+	}
+	if db.DataSource() != source {
+		t.Fatal(fmt.Sprintf("want '%s', but got '%s'", source, db.DataSource()))
+	}
+
+}
+func TestDB_CopyIn(t *testing.T) {
+	source := "user=gorm password=gorm DB.name=gorm port=9920 sslmode=disable"
+	db, er := gorm.Open("postgres", source)
+	if er != nil {
+		panic(fmt.Sprintf("No error should happen when connecting to test database, but got err=%+v", er))
+	}
+	e := db.Exec("create table if not exists example(name varchar, age integer)").Error
+	defer func() {
+		er := db.Exec("drop table if exists example").Error
+		if er != nil {
+			t.Fatal(e.Error())
+		}
+	}()
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	defer db.Exec("drop table")
+	var args = make([][]interface{}, 0)
+	args = append(args, []interface{}{
+		"tom", 9,
+	}, []interface{}{
+		"sara", 10,
+	}, []interface{}{
+		"jim", 11,
+	})
+	e = db.CopyIn(true, "example", args, "name", "age")
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	type Example struct {
+		Name string
+		Age  int
+	}
+	var examples = make([]Example, 0)
+	e = db.Raw("select * from example").Find(&examples).Error
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	if len(examples) == 0 {
+		t.Fatal("examples length wants more than 3, but got 0")
+	}
+	fmt.Println(examples)
+}
+
 func BenchmarkGorm(b *testing.B) {
 	b.N = 2000
 	for x := 0; x < b.N; x++ {

--- a/main_test.go
+++ b/main_test.go
@@ -1072,6 +1072,9 @@ func (e Example) TableName() string {
 	return "example"
 }
 func TestDB_CopyIn(t *testing.T) {
+	if DB.Dialect().GetName()!="postgres"{
+		return
+	}
 	if !DB.HasTable(&Example{}) {
 		if e := DB.CreateTable(&Example{}).Error; e != nil {
 			t.Fatal(e.Error())

--- a/main_test.go
+++ b/main_test.go
@@ -1060,29 +1060,26 @@ func TestBlockGlobalUpdate(t *testing.T) {
 }
 
 func TestDB_DataSource(t *testing.T) {
-	source := "user=gorm password=gorm DB.name=gorm port=9920 sslmode=disable"
-	if DB.DataSource() != source {
-		t.Fatal(fmt.Sprintf("want '%s', but got '%s'", source, DB.DataSource()))
-	}
-
+	fmt.Println(DB.DataSource())
 }
 
-type Example struct{
+type Example struct {
 	Name string
-	Age int
+	Age  int
 }
-func (e Example) TableName()string{
+
+func (e Example) TableName() string {
 	return "example"
 }
 func TestDB_CopyIn(t *testing.T) {
 	if !DB.HasTable(&Example{}) {
-		if e:=DB.Create(&Example{}).Error;e!=nil {
+		if e := DB.CreateTable(&Example{}).Error; e != nil {
 			t.Fatal(e.Error())
 		}
 	}
 	defer func() {
 		if DB.HasTable(&Example{}) {
-			if e:=DB.DropTable(&Example{}).Error;e!=nil{
+			if e := DB.DropTable(&Example{}).Error; e != nil {
 				t.Fatal(e.Error())
 			}
 		}
@@ -1098,10 +1095,6 @@ func TestDB_CopyIn(t *testing.T) {
 	e := DB.CopyIn(true, "example", args, "name", "age")
 	if e != nil {
 		t.Fatal(e.Error())
-	}
-	type Example struct {
-		Name string
-		Age  int
 	}
 	var examples = make([]Example, 0)
 	e = DB.Model(&Example{}).Find(&examples).Error

--- a/migration_test.go
+++ b/migration_test.go
@@ -294,7 +294,9 @@ func runMigration() {
 
 	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}, &Place{}}
 	for _, value := range values {
-		DB.DropTable(value)
+		if DB.HasTable(value){
+			DB.DropTable(value)
+		}
 	}
 	if err := DB.AutoMigrate(values...).Error; err != nil {
 		panic(fmt.Sprintf("No error should happen when create table, but got %+v", err))

--- a/migration_test.go
+++ b/migration_test.go
@@ -188,11 +188,11 @@ func (i *Num) Scan(src interface{}) error {
 }
 
 type Animal struct {
-	Counter    uint64    `gorm:"primary_key:yes"`
-	Name       string    `sql:"DEFAULT:'galeone'"`
-	From       string    //test reserved sql keyword as field name
+	Counter    uint64 `gorm:"primary_key:yes"`
+	Name       string `sql:"DEFAULT:'galeone'"`
+	From       string //test reserved sql keyword as field name
 	Age        time.Time `sql:"DEFAULT:current_timestamp"`
-	unexported string    // unexported value
+	unexported string // unexported value
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }
@@ -294,7 +294,7 @@ func runMigration() {
 
 	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}, &Place{}}
 	for _, value := range values {
-		if DB.HasTable(value){
+		if DB.HasTable(value) {
 			DB.DropTable(value)
 		}
 	}


### PR DESCRIPTION
### What did this pull request do?
Refer:
#2176 
New feature:
Allow postgres dialect using CopyIn function to insert a big amount of data in the same time.
Added apis:
```go
// DataSource returns its opened dataSource:
//    gorm.Open("postgres", "host=localhost user=root dbname=test sslmode=disable password=123")
// Then dataSource = "host=localhost user=root dbname=test sslmode=disable password=123"
func (s *DB) DataSource() string

// CopyDB returns its origin db engine whose driver is github.com/lib/pq
func (s *DB) CopyDB() (*sql.DB, error)

// CopyIn for postgres
func (s *DB) CopyIn(closeAfterUsed bool, table string, args [][]interface{}, columns ...string) error
```