### PR TITLE
Better log output int8, int, int16, int32, int64, float32, float64, bool.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -63,7 +63,13 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 							formattedValues = append(formattedValues, "NULL")
 						}
 					} else {
-						formattedValues = append(formattedValues, fmt.Sprintf("'%v'", value))
+						switch value.(type) {
+						case int, int16, int32, int64, int8, float32, float64:
+							formattedValues = append(formattedValues, fmt.Sprintf("%v", value))
+							break
+						default:
+							formattedValues = append(formattedValues, fmt.Sprintf("'%v'", value))
+						}
 					}
 				} else {
 					formattedValues = append(formattedValues, "NULL")

--- a/logger.go
+++ b/logger.go
@@ -64,7 +64,7 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 						}
 					} else {
 						switch value.(type) {
-						case int, int16, int32, int64, int8, float32, float64:
+						case int8, int, int16, int32, int64, float32, float64, bool:
 							formattedValues = append(formattedValues, fmt.Sprintf("%v", value))
 							break
 						default:


### PR DESCRIPTION
# Better log output int, int16, int32, int64, int8, float32, float64.
---

such as:

---
#idres field is int

# fixed **before**
 SELECT count(*) FROM xxxx  WHERE idres = **`'22' `**


# fixed **after**
 SELECT count(*) FROM xxxx  WHERE idres = **`22`**

---

remove quote `''` when  **int, int16, int32, int64, int8, float32, float64**.









-----



