### PR TITLE
not to quote int, float and bool value in query log

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -27,6 +27,21 @@ func isPrintable(s string) bool {
 	return true
 }
 
+func isNumber(v interface{}) bool {
+	switch v.(type) {
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, uintptr,
+		float32, float64:
+		return true
+	}
+	return false
+}
+
+func isBool(v interface{}) bool {
+	_, ok := v.(bool)
+	return ok
+}
+
 var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 	if len(values) > 1 {
 		var (
@@ -56,6 +71,8 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 						} else {
 							formattedValues = append(formattedValues, "'<binary>'")
 						}
+					} else if isNumber(value) || isBool(value) {
+						formattedValues = append(formattedValues, fmt.Sprint(value))
 					} else if r, ok := value.(driver.Valuer); ok {
 						if value, err := r.Value(); err == nil && value != nil {
 							formattedValues = append(formattedValues, fmt.Sprintf("'%v'", value))


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [ ] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

not to quote int, float and bool value in query log.

```sql
mysql> desc test;
+-------+--------------+------+-----+---------+-------+
| Field | Type         | Null | Key | Default | Extra |
+-------+--------------+------+-----+---------+-------+
| id    | int(11)      | NO   | PRI | NULL    |       |
| name  | varchar(100) | YES  |     | NULL    |       |
| flag  | tinyint(1)   | YES  |     | NULL    |       |
| ratio | float        | YES  |     | NULL    |       |
+-------+--------------+------+-----+---------+-------+
4 rows in set (0.01 sec)

mysql> INSERT INTO `test` (`id`,`name`,`flag`,`ratio`) VALUES ('1', 'test', 'true', '1.234');
ERROR 1366 (HY000): Incorrect integer value: 'true' for column 'flag' at row 1

mysql> INSERT INTO `test` (`id`,`name`,`flag`,`ratio`) VALUES (1, 'test', true, 1.234);
Query OK, 1 row affected (0.08 sec)
```