### PR TITLE
fix TagSettings' map  has "":"" value

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -625,6 +625,9 @@ func (scope *Scope) GetStructFields() (fields []*StructField) {
 func parseTagSetting(tags reflect.StructTag) map[string]string {
 	setting := map[string]string{}
 	for _, str := range []string{tags.Get("sql"), tags.Get("gorm")} {
+		if str == "" {
+			continue
+		}
 		tags := strings.Split(str, ";")
 		for _, value := range tags {
 			v := strings.Split(value, ":")


### PR DESCRIPTION
when `str` variable is `empty string`, TagSettings' map  has  `"":""`  value like this:

![image](https://user-images.githubusercontent.com/13718575/55534618-7d3b8e80-56e7-11e9-807f-811059e5009d.png)

and this code will `print 1` although the `str` variable is empty string:

```go

	str := ""
	tags := strings.Split(str, ";")
	fmt.Println(len(tags))

```

try this: https://play.golang.org/p/ISj1UhSlB4x