### PR TITLE
mysql column comment in create table or add column

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -126,6 +126,13 @@ var ParseFieldStructForDialect = func(field *StructField, dialect Dialect) (fiel
 		additionalType = additionalType + " DEFAULT " + value
 	}
 
+	// add mysql column comment
+	if dialect.GetName() == "mysql" {
+		if value, ok := field.TagSettingsGet("COMMENT"); ok {
+			additionalType = additionalType + " COMMENT " + value
+		}
+	}
+
 	if value, ok := field.TagSettingsGet("COMMENT"); ok {
 		additionalType = additionalType + " COMMENT " + value
 	}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
add mysql column comment in create table or add column

usage:  
```
type T struct{
    comment  string  `gorm:"not null;COMMENT:'is comment'"`
}
```
