### PR TITLE
Fixed nil error when first updates with struct

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1182,6 +1182,27 @@ func TestFloatColumnPrecision(t *testing.T) {
 	}
 }
 
+func TestWhereUpdates(t *testing.T) {
+	type OwnerEntity struct {
+		gorm.Model
+		OwnerID   uint
+		OwnerType string
+	}
+
+	type SomeEntity struct {
+		gorm.Model
+		Name        string
+		OwnerEntity OwnerEntity `gorm:"polymorphic:Owner"`
+	}
+
+	db := DB.Debug()
+	db.DropTable(&SomeEntity{})
+	db.AutoMigrate(&SomeEntity{})
+
+	a := SomeEntity{Name: "test"}
+	db.Model(&a).Where(a).Updates(SomeEntity{Name: "test2"})
+}
+
 func BenchmarkGorm(b *testing.B) {
 	b.N = 2000
 	for x := 0; x < b.N; x++ {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
```go
type OwnerEntity struct {
		gorm.Model
		OwnerID   uint
		OwnerType string
	}

	type SomeEntity struct {
		gorm.Model
		Name        string
		OwnerEntity OwnerEntity `gorm:"polymorphic:Owner"`
	}

	db := DB.Debug()
	db.DropTable(&SomeEntity{})
	db.AutoMigrate(&SomeEntity{})

	a := SomeEntity{Name: "test"}
	db.Model(&a).Where(a).Updates(SomeEntity{Name: "test2"})

// will panic: runtime error: invalid memory address or nil pointer dereference
```

because tag `gorm:"polymorphic"` will execute the following code but scope.db is nil:

```go
relationship.PolymorphicValue = scope.TableName()

func (scope *Scope) TableName() string {
    // ....
    return scope.GetModelStruct().TableName(scope.db.Model(scope.Value))
}
```

Replaces https://github.com/jinzhu/gorm/pull/2105