### PR TITLE
Fix CallbackProcessor.Get() for removed or replaced same name callback

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -135,11 +135,15 @@ func (cp *CallbackProcessor) Replace(callbackName string, callback func(scope *S
 //    db.Callback().Create().Get("gorm:create")
 func (cp *CallbackProcessor) Get(callbackName string) (callback func(scope *Scope)) {
 	for _, p := range cp.parent.processors {
-		if p.name == callbackName && p.kind == cp.kind && !cp.remove {
-			return *p.processor
+		if p.name == callbackName && p.kind == cp.kind {
+			if p.remove {
+				callback = nil
+			} else {
+				callback = *p.processor
+			}
 		}
 	}
-	return nil
+	return
 }
 
 // getRIndex get right index from string slice

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -2,11 +2,10 @@ package gorm_test
 
 import (
 	"errors"
-
-	"github.com/jinzhu/gorm"
-
 	"reflect"
 	"testing"
+
+	"github.com/jinzhu/gorm"
 )
 
 func (s *Product) BeforeCreate() (err error) {
@@ -173,5 +172,48 @@ func TestCallbacksWithErrors(t *testing.T) {
 	DB.Delete(&p5)
 	if err := DB.First(&Product{}, "code = ?", "after_delete_error").Error; err != nil {
 		t.Errorf("Record shouldn't be deleted because of an error happened in after delete callback")
+	}
+}
+
+func TestGetCallback(t *testing.T) {
+	scope := DB.NewScope(nil)
+
+	if DB.Callback().Create().Get("gorm:test_callback") != nil {
+		t.Errorf("`gorm:test_callback` should be nil")
+	}
+
+	DB.Callback().Create().Register("gorm:test_callback", func(scope *gorm.Scope) { scope.Set("gorm:test_callback_value", 1) })
+	callback := DB.Callback().Create().Get("gorm:test_callback")
+	if callback == nil {
+		t.Errorf("`gorm:test_callback` should be non-nil")
+	}
+	callback(scope)
+	if v, ok := scope.Get("gorm:test_callback_value"); !ok || v != 1 {
+		t.Errorf("`gorm:test_callback_value` should be `1, true` but `%v, %v`", v, ok)
+	}
+
+	DB.Callback().Create().Replace("gorm:test_callback", func(scope *gorm.Scope) { scope.Set("gorm:test_callback_value", 2) })
+	callback = DB.Callback().Create().Get("gorm:test_callback")
+	if callback == nil {
+		t.Errorf("`gorm:test_callback` should be non-nil")
+	}
+	callback(scope)
+	if v, ok := scope.Get("gorm:test_callback_value"); !ok || v != 2 {
+		t.Errorf("`gorm:test_callback_value` should be `2, true` but `%v, %v`", v, ok)
+	}
+
+	DB.Callback().Create().Remove("gorm:test_callback")
+	if DB.Callback().Create().Get("gorm:test_callback") != nil {
+		t.Errorf("`gorm:test_callback` should be nil")
+	}
+
+	DB.Callback().Create().Register("gorm:test_callback", func(scope *gorm.Scope) { scope.Set("gorm:test_callback_value", 3) })
+	callback = DB.Callback().Create().Get("gorm:test_callback")
+	if callback == nil {
+		t.Errorf("`gorm:test_callback` should be non-nil")
+	}
+	callback(scope)
+	if v, ok := scope.Get("gorm:test_callback_value"); !ok || v != 3 {
+		t.Errorf("`gorm:test_callback_value` should be `3, true` but `%v, %v`", v, ok)
 	}
 }


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

`CallbackProcessor.Get()` return first callback even if removed or replaced.
I fixed to return last one or nil (when removed).
