### PR TITLE
Fixed import formatting to match goimports

### DIFF
--- a/dialects/postgres/postgres.go
+++ b/dialects/postgres/postgres.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	_ "github.com/lib/pq"
 	"github.com/lib/pq/hstore"
 )


### PR DESCRIPTION
This is really just to prevent CI tools from constantly trying to rewrite this piece of code.