### PR TITLE
Rename expr type to make it public.

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,8 +209,8 @@ func (s *DB) NewScope(value interface{}) *Scope {
 	return scope
 }
 
-// QueryExpr returns the query as expr object
-func (s *DB) QueryExpr() *expr {
+// QueryExpr returns the query as SqlExpr object
+func (s *DB) QueryExpr() *SqlExpr {
 	scope := s.NewScope(s.Value)
 	scope.InstanceSet("skip_bindvar", true)
 	scope.prepareQuerySQL()
@@ -219,7 +219,7 @@ func (s *DB) QueryExpr() *expr {
 }
 
 // SubQuery returns the query as sub query
-func (s *DB) SubQuery() *expr {
+func (s *DB) SubQuery() *SqlExpr {
 	scope := s.NewScope(s.Value)
 	scope.InstanceSet("skip_bindvar", true)
 	scope.prepareQuerySQL()

--- a/scope.go
+++ b/scope.go
@@ -257,7 +257,7 @@ func (scope *Scope) CallMethod(methodName string) {
 func (scope *Scope) AddToVars(value interface{}) string {
 	_, skipBindVar := scope.InstanceGet("skip_bindvar")
 
-	if expr, ok := value.(*expr); ok {
+	if expr, ok := value.(*SqlExpr); ok {
 		exp := expr.expr
 		for _, arg := range expr.args {
 			if skipBindVar {
@@ -806,7 +806,7 @@ func (scope *Scope) orderSQL() string {
 	for _, order := range scope.Search.orders {
 		if str, ok := order.(string); ok {
 			orders = append(orders, scope.quoteIfPossible(str))
-		} else if expr, ok := order.(*expr); ok {
+		} else if expr, ok := order.(*SqlExpr); ok {
 			exp := expr.expr
 			for _, arg := range expr.args {
 				exp = strings.Replace(exp, "?", scope.AddToVars(arg), 1)
@@ -933,7 +933,7 @@ func (scope *Scope) updatedAttrsWithValues(value interface{}) (results map[strin
 
 	for key, value := range convertInterfaceToMap(value, true, scope.db) {
 		if field, ok := scope.FieldByName(key); ok && scope.changeableField(field) {
-			if _, ok := value.(*expr); ok {
+			if _, ok := value.(*SqlExpr); ok {
 				hasUpdate = true
 				results[field.DBName] = value
 			} else {

--- a/search.go
+++ b/search.go
@@ -98,7 +98,7 @@ func (s *search) Group(query string) *search {
 }
 
 func (s *search) Having(query interface{}, values ...interface{}) *search {
-	if val, ok := query.(*expr); ok {
+	if val, ok := query.(*SqlExpr); ok {
 		s.havingConditions = append(s.havingConditions, map[string]interface{}{"query": val.expr, "args": val.args})
 	} else {
 		s.havingConditions = append(s.havingConditions, map[string]interface{}{"query": query, "args": values})

--- a/utils.go
+++ b/utils.go
@@ -58,15 +58,15 @@ func newSafeMap() *safeMap {
 }
 
 // SQL expression
-type expr struct {
+type SqlExpr struct {
 	expr string
 	args []interface{}
 }
 
 // Expr generate raw SQL expression, for example:
 //     DB.Model(&product).Update("price", gorm.Expr("price * ? + ?", 2, 100))
-func Expr(expression string, args ...interface{}) *expr {
-	return &expr{expr: expression, args: args}
+func Expr(expression string, args ...interface{}) *SqlExpr {
+	return &SqlExpr{expr: expression, args: args}
 }
 
 func indirect(reflectValue reflect.Value) reflect.Value {


### PR DESCRIPTION
In several cases I've really wanted the ability to return the result of calling `QueryExpr` from a function.  The `expr` type being private prevents being able to write a function that returns or accepts it.  The public constructor for this type doesn't do anything besides forward the args.  I'm assuming this was private in the first place to allow future refactoring, but this has been stable for some time.  This would be a significant usability improvement.