### PR TITLE
add a field(LastInsertId) in scope to getLastInsertId

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -128,6 +128,8 @@ func createCallback(scope *Scope) {
 			if result, err := scope.SQLDB().Exec(scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
 				// set rows affected count
 				scope.db.RowsAffected, _ = result.RowsAffected()
+				// set lastInsertId
+				scope.db.LastInsertId, _ = result.LastInsertId()
 
 				// set primary value to primary field
 				if primaryField != nil && primaryField.IsBlank {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ type DB struct {
 	Value        interface{}
 	Error        error
 	RowsAffected int64
+	LastInsertId int64
 
 	// single db
 	db                SQLCommon

--- a/scope.go
+++ b/scope.go
@@ -382,6 +382,9 @@ func (scope *Scope) Exec() *Scope {
 			if count, err := result.RowsAffected(); scope.Err(err) == nil {
 				scope.db.RowsAffected = count
 			}
+			if lastInsertId, err := result.LastInsertId(); scope.Err(err) == nil {
+				scope.db.LastInsertId = lastInsertId
+			}
 		}
 	}
 	return scope


### PR DESCRIPTION

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

add a filed to solve cannot get lastInsertid when insert by Exec(“insert into...”) 

### What did this pull request do?
add a field: LastInsertId  appointed by result.LastInsertId()
