### PR TITLE
fix gorm logger insert timezero 0001-01-01

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -49,7 +49,11 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 				if indirectValue.IsValid() {
 					value = indirectValue.Interface()
 					if t, ok := value.(time.Time); ok {
-						formattedValues = append(formattedValues, fmt.Sprintf("'%v'", t.Format("2006-01-02 15:04:05")))
+						if t.IsZero() {
+							formattedValues = append(formattedValues, fmt.Sprintf("'%v'", "0000-00-00 00:00:00"))
+						} else {
+							formattedValues = append(formattedValues, fmt.Sprintf("'%v'", t.Format("2006-01-02 15:04:05")))
+						}
 					} else if b, ok := value.([]byte); ok {
 						if str := string(b); isPrintable(str) {
 							formattedValues = append(formattedValues, fmt.Sprintf("'%v'", str))


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

```
logger:

[sql D:/mygo/src/ch/t/run.go:309 1.9954ms INSERT  INTO `a` (`user_id`,`vip_expire_time`,`message_type`,`click_tab_time`) VALUES (?,?,?,?) [0 0001-01-01 00:00:00 +0000 UTC  0001-01-01 00:00:00 +0000 UTC] 1]

?[33m[2019-08-28 10:53:01]?[0m  ?[36;1m[0.99ms]?[0m  INSERT  INTO `a` (`user_id`,`vip_expire_time`,`message_type`,`click_tab_time`) VALUES (3,'0001-01-01 00:00:00','hello','0001-01-01 00:00:00')
```

check timezero:
```
INSERT  INTO `a` (`user_id`,`vip_expire_time`,`message_type`,`click_tab_time`) VALUES (3,'0000-00-00 00:00:00','hello','0000-00-00 00:00:00')
```