### PR TITLE
Fixed Ignore Blank Fields On Create

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -63,7 +63,7 @@ func createCallback(scope *Scope) {
 					if field.IsBlank && field.HasDefaultValue {
 						blankColumnsWithDefaultValue = append(blankColumnsWithDefaultValue, scope.Quote(field.DBName))
 						scope.InstanceSet("gorm:blank_columns_with_default_value", blankColumnsWithDefaultValue)
-					} else if !field.IsPrimaryKey || !field.IsBlank {
+					} else if !field.IsBlank {
 						columns = append(columns, scope.Quote(field.DBName))
 						placeholders = append(placeholders, scope.AddToVars(field.Field.Interface()))
 					}


### PR DESCRIPTION
Removed erroneous IsPrimaryKey check which caused fields that were not part of the Primary Key but were Blank to be inserted.

(Particularly a problem because DeletedAt would be set to the zero value.)

Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Fixed an issue where zero valued fields would be inserted instead of NULL/default values. This includes the DeletedAt field which would cause all rows to be automatically marked as deleted