### PR TITLE
Scan now skips ignored fields when setting the values of a struct field

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -493,6 +493,9 @@ func (scope *Scope) scan(rows *sql.Rows, columns []string, fields []*Field) {
 		}
 
 		for fieldIndex, field := range selectFields {
+			if field.IsIgnored {
+				continue
+			}
 			if field.DBName == column {
 				if field.Field.Kind() == reflect.Ptr {
 					values[index] = field.Field.Addr().Interface()


### PR DESCRIPTION
In the case a field of a struct was explicitly ignored by gorm (i.e. using the attribute `gorm:"-"`), scan would attempt to populate the ignored field with data coming from the next field.
In some cases this would lead to a crash due to incompatible data types while in other cases this would populate the field with the wrong data.

Possibly related to issue #1826 