### PR TITLE
MSSQL Create() fix: Add LastInsertIDReturningSuffix to dialect

### DIFF
--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -191,7 +191,7 @@ func (mssql) SelectFromDummyTable() string {
 }
 
 func (mssql) LastInsertIDReturningSuffix(tableName, columnName string) string {
-	return ""
+	return "SELECT id = convert(bigint, SCOPE_IDENTITY())"
 }
 
 func (mssql) DefaultValueStr() string {


### PR DESCRIPTION
Per https://github.com/denisenkom/go-mssqldb/issues/355

Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Fixes #2649, error upon Create() when using MSSQL dialect:
> LastInsertId is not supported. Please use the OUTPUT clause or add select ID = convert(bigint, SCOPE_IDENTITY()) to the end of your query.