### PR TITLE
support custom namer 

### DIFF
--- a/naming.go
+++ b/naming.go
@@ -66,7 +66,7 @@ func ToColumnName(name string) string {
 	return TheNamingStrategy.ColumnName(name)
 }
 
-// mapping cache map
+// Smap is mapping cache map
 var Smap = newSafeMap()
 
 func defaultNamer(name string) string {

--- a/naming.go
+++ b/naming.go
@@ -66,7 +66,7 @@ func ToColumnName(name string) string {
 	return TheNamingStrategy.ColumnName(name)
 }
 
-var smap = newSafeMap()
+var Smap = newSafeMap()
 
 func defaultNamer(name string) string {
 	const (
@@ -74,7 +74,7 @@ func defaultNamer(name string) string {
 		upper = true
 	)
 
-	if v := smap.Get(name); v != "" {
+	if v := Smap.Get(name); v != "" {
 		return v
 	}
 
@@ -119,6 +119,6 @@ func defaultNamer(name string) string {
 	buf.WriteByte(value[len(value)-1])
 
 	s := strings.ToLower(buf.String())
-	smap.Set(name, s)
+	Smap.Set(name, s)
 	return s
 }

--- a/naming.go
+++ b/naming.go
@@ -66,6 +66,7 @@ func ToColumnName(name string) string {
 	return TheNamingStrategy.ColumnName(name)
 }
 
+// mapping cache map
 var Smap = newSafeMap()
 
 func defaultNamer(name string) string {

--- a/naming_test.go
+++ b/naming_test.go
@@ -32,11 +32,40 @@ func TestTheNamingStrategy(t *testing.T) {
 
 func TestAddNamingStrategy(t *testing.T) {
 
-	// users can set their custom namer
-	custom := &gorm.NamingStrategy{
-		Column: CustomNamer,
-	}
-	gorm.AddNamingStrategy(custom)
+	// users can set their custom namer and use `Smap` to cache result
+	gorm.AddNamingStrategy(&gorm.NamingStrategy{
+		Column: func(name string) string {
+			// set `smap` public access and users can use it to cache
+			if v := gorm.Smap.Get(name); v != "" {
+				return v
+			}
+
+			const (
+				//lower = false
+				upper = true
+			)
+
+			var (
+				value    = name
+				buf      = bytes.NewBufferString("")
+				currCase bool
+			)
+
+			for i, v := range value {
+				currCase = bool(value[i] >= 'A' && value[i] <= 'Z')
+				if i == 0 && currCase == upper {
+					buf.WriteRune(v + 32)
+				} else {
+					buf.WriteRune(v)
+				}
+			}
+
+			s := buf.String()
+			gorm.Smap.Set(name, s)
+
+			return s
+		},
+	})
 
 	// test
 	cases := []struct {
@@ -44,10 +73,6 @@ func TestAddNamingStrategy(t *testing.T) {
 		namer    gorm.Namer
 		expected string
 	}{
-		{name: "auth", expected: "auth", namer: gorm.TheNamingStrategy.DB},
-		{name: "userRestrictions", expected: "user_restrictions", namer: gorm.TheNamingStrategy.Table},
-
-		{name: "clientID", expected: "clientID", namer: gorm.TheNamingStrategy.Column},
 		{name: "Client0ID", expected: "client0ID", namer: gorm.TheNamingStrategy.Column},
 		{name: "_Client_ID_", expected: "_Client_ID_", namer: gorm.TheNamingStrategy.Column},
 	}
@@ -61,38 +86,6 @@ func TestAddNamingStrategy(t *testing.T) {
 		})
 	}
 
-}
-
-func CustomNamer(name string) string {
-	// set `smap` public access and users can use it to cache
-	if v := gorm.Smap.Get(name); v != "" {
-		return v
-	}
-
-	const (
-		lower = false
-		upper = true
-	)
-
-	var (
-		value    = name
-		buf      = bytes.NewBufferString("")
-		currCase bool
-	)
-
-	for i, v := range value {
-		currCase = bool(value[i] >= 'A' && value[i] <= 'Z')
-		if i == 0 && currCase == upper {
-			buf.WriteRune(v + 32)
-		} else {
-			buf.WriteRune(v)
-		}
-	}
-
-	s := buf.String()
-	gorm.Smap.Set(name, s)
-
-	return s
 }
 
 func TestNamingStrategy(t *testing.T) {

--- a/naming_test.go
+++ b/naming_test.go
@@ -1,6 +1,7 @@
 package gorm_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/jinzhu/gorm"
@@ -27,6 +28,71 @@ func TestTheNamingStrategy(t *testing.T) {
 		})
 	}
 
+}
+
+func TestAddNamingStrategy(t *testing.T) {
+
+	// users can set their custom namer
+	custom := &gorm.NamingStrategy{
+		Column: CustomNamer,
+	}
+	gorm.AddNamingStrategy(custom)
+
+	// test
+	cases := []struct {
+		name     string
+		namer    gorm.Namer
+		expected string
+	}{
+		{name: "auth", expected: "auth", namer: gorm.TheNamingStrategy.DB},
+		{name: "userRestrictions", expected: "user_restrictions", namer: gorm.TheNamingStrategy.Table},
+
+		{name: "clientID", expected: "clientID", namer: gorm.TheNamingStrategy.Column},
+		{name: "Client0ID", expected: "client0ID", namer: gorm.TheNamingStrategy.Column},
+		{name: "_Client_ID_", expected: "_Client_ID_", namer: gorm.TheNamingStrategy.Column},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.namer(c.name)
+			if result != c.expected {
+				t.Errorf("error in naming strategy. expected: %v got :%v\n", c.expected, result)
+			}
+		})
+	}
+
+}
+
+func CustomNamer(name string) string {
+	// set `smap` public access and users can use it to cache
+	if v := gorm.Smap.Get(name); v != "" {
+		return v
+	}
+
+	const (
+		lower = false
+		upper = true
+	)
+
+	var (
+		value    = name
+		buf      = bytes.NewBufferString("")
+		currCase bool
+	)
+
+	for i, v := range value {
+		currCase = bool(value[i] >= 'A' && value[i] <= 'Z')
+		if i == 0 && currCase == upper {
+			buf.WriteRune(v + 32)
+		} else {
+			buf.WriteRune(v)
+		}
+	}
+
+	s := buf.String()
+	gorm.Smap.Set(name, s)
+
+	return s
 }
 
 func TestNamingStrategy(t *testing.T) {


### PR DESCRIPTION
hi.
I had a problem that the mapping of existed db tables column and models，just like：

db table define:
```
CREATE TABLE `tags` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(100) ,
  `createdOn` int(10) ,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;

``` 
model define：
```
type Tag struct{
    Id int
    Name string
    CreateOn int 
}
```

if i can not set `gorm:"column:createdOn"` for CreateOn field ,it will be mapping to created_on,
so i check the source code about this mapping method and try to custom.
but i can not do it because the `smap` is not public access.

this pr is solve it,and gorm users can custom column namer and use `smap` to cache.