### PR TITLE
fix(HasTable): database name

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -165,7 +165,7 @@ func (s mysql) HasForeignKey(tableName string, foreignKeyName string) bool {
 func (s mysql) HasTable(tableName string) bool {
 	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
 	var name string
-	if err := s.db.QueryRow(fmt.Sprintf("SHOW TABLES FROM %s WHERE Tables_in_%s = ?", currentDatabase, currentDatabase), tableName).Scan(&name); err != nil {
+	if err := s.db.QueryRow(fmt.Sprintf("SHOW TABLES FROM `%s` WHERE `Tables_in_%s` = ?", currentDatabase, currentDatabase), tableName).Scan(&name); err != nil {
 		if err == sql.ErrNoRows {
 			return false
 		}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -165,6 +165,7 @@ func (s mysql) HasForeignKey(tableName string, foreignKeyName string) bool {
 func (s mysql) HasTable(tableName string) bool {
 	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
 	var name string
+	// allow mysql database name with '-' character
 	if err := s.db.QueryRow(fmt.Sprintf("SHOW TABLES FROM `%s` WHERE `Tables_in_%s` = ?", currentDatabase, currentDatabase), tableName).Scan(&name); err != nil {
 		if err == sql.ErrNoRows {
 			return false


### PR DESCRIPTION
allow mysql database name with '-' character

Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
implement issue #2715 
allow mysql database name with '-' character

dialect_mysql.go line:168

```go
func (s mysql) HasTable(tableName string) bool {
	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
	var name string
	// allow mysql database name with '-' character
	if err := s.db.QueryRow(fmt.Sprintf("SHOW TABLES FROM `%s` WHERE `Tables_in_%s` = ?", currentDatabase, currentDatabase), tableName).Scan(&name); err != nil {
		if err == sql.ErrNoRows {
			return false
		}
		panic(err)
	} else {
		return true
	}
}
```