### PR TITLE
fix a race condition on IsForeignKey that is being detected by -race

### DIFF
--- a/model_struct_test.go
+++ b/model_struct_test.go
@@ -1,0 +1,93 @@
+package gorm_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+)
+
+type ModelA struct {
+	gorm.Model
+	Name string
+
+	ModelCs []ModelC `gorm:"foreignkey:OtherAID"`
+}
+
+type ModelB struct {
+	gorm.Model
+	Name string
+
+	ModelCs []ModelC `gorm:"foreignkey:OtherBID"`
+}
+
+type ModelC struct {
+	gorm.Model
+	Name string
+
+	OtherAID uint64
+	OtherA   *ModelA `gorm:"foreignkey:OtherAID"`
+	OtherBID uint64
+	OtherB   *ModelB `gorm:"foreignkey:OtherBID"`
+}
+
+// This test will try to cause a race condition on the model's foreignkey metadata
+func TestModelStructRaceSameModel(t *testing.T) {
+	// use a WaitGroup to execute as much in-sync as possible
+	// it's more likely to hit a race condition than without
+	n := 32
+	start := sync.WaitGroup{}
+	start.Add(n)
+
+	// use another WaitGroup to know when the test is done
+	done := sync.WaitGroup{}
+	done.Add(n)
+
+	for i := 0; i < n; i++ {
+		go func() {
+			start.Wait()
+
+			// call GetStructFields, this had a race condition before we fixed it
+			DB.NewScope(&ModelA{}).GetStructFields()
+
+			done.Done()
+		}()
+
+		start.Done()
+	}
+
+	done.Wait()
+}
+
+// This test will try to cause a race condition on the model's foreignkey metadata
+func TestModelStructRaceDifferentModel(t *testing.T) {
+	// use a WaitGroup to execute as much in-sync as possible
+	// it's more likely to hit a race condition than without
+	n := 32
+	start := sync.WaitGroup{}
+	start.Add(n)
+
+	// use another WaitGroup to know when the test is done
+	done := sync.WaitGroup{}
+	done.Add(n)
+
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			start.Wait()
+
+			// call GetStructFields, this had a race condition before we fixed it
+			if i%2 == 0 {
+				DB.NewScope(&ModelA{}).GetStructFields()
+			} else {
+				DB.NewScope(&ModelB{}).GetStructFields()
+			}
+
+			done.Done()
+		}()
+
+		start.Done()
+	}
+
+	done.Wait()
+}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

### What did this pull request do?

When you run tests with the `-race` flag there's a small chance to hit a race condition in gorm.  
This particular race condition is harmless, but it's very annoying when a CI pipeline fails over it and if everyone who get's it at some point has to debug to figure out what is going on that's a lot of needless time wasted ...

The `foreignField.IsForeignKey = true` line can be hit in a few different scenarios (there's also 3 places where it's done), either when 2 models have the same relation or when the same model is used for the "first time" in parallel.

I've added a global mutex to use, I think it might be more "correct" to add a mutex to `StructField`, but it seems like overkill to create so many mutex.  
If you guys prefer a mutex per `StructField` then just let me know, it's easily changed.

Unfortunately it's rather hard to write a reliable test for this, the tests I added are more likely to hit the race condition if your machine has enough cores and the `n := 32` seems to greatly increase the chance to hit it compared to using `n := 12`(I got 12 cores).  
With 1 core it never hits it (duh), with 2 cores it's about 50% chance to hit it, with 4 cores it always hits it (on my machine).  

Since most CI pipelines (specially free ones) run on 1 core VMs, the likely won't catch the race conditions, but devs running tests from their own machine should (if a race condition comes back) so I think it's worth having the tests for it.


```
WARNING: DATA RACE
Write at 0x00c000568840 by goroutine 51:
  github.com/jinzhu/gorm.(*Scope).GetModelStruct.func1()
      /work/gorm/model_struct.go:428 +0x1ed8
  github.com/jinzhu/gorm.(*Scope).GetModelStruct()
      /work/gorm/model_struct.go:645 +0x206f
  github.com/jinzhu/gorm.(*Scope).GetStructFields()
      /work/gorm/model_struct.go:650 +0x3c
  github.com/jinzhu/gorm.(*Scope).GetModelStruct.func2()
      /work/gorm/model_struct.go:458 +0x2f0
  github.com/jinzhu/gorm.(*Scope).GetModelStruct()
      /work/gorm/model_struct.go:645 +0x206f
  github.com/jinzhu/gorm.(*Scope).GetStructFields()
      /work/gorm/model_struct.go:650 +0x3c
  github.com/jinzhu/gorm.(*Scope).GetModelStruct.func1()
      /work/gorm/model_struct.go:366 +0x1a79
  github.com/jinzhu/gorm.(*Scope).GetModelStruct()
      /work/gorm/model_struct.go:645 +0x206f
  github.com/jinzhu/gorm.(*Scope).GetStructFields()
      /work/gorm/model_struct.go:650 +0x3c
  github.com/jinzhu/gorm_test.TestModelStructRaceSameModel.func1()
      /work/gorm/model_struct_test.go:51 +0xe3

Previous write at 0x00c000568840 by goroutine 42:
  github.com/jinzhu/gorm.(*Scope).GetModelStruct.func1()
      /work/gorm/model_struct.go:428 +0x1ed8
  github.com/jinzhu/gorm.(*Scope).GetModelStruct()
      /work/gorm/model_struct.go:645 +0x206f
  github.com/jinzhu/gorm.(*Scope).GetStructFields()
      /work/gorm/model_struct.go:650 +0x3c
  github.com/jinzhu/gorm.(*Scope).GetModelStruct.func2()
      /work/gorm/model_struct.go:458 +0x2f0
  github.com/jinzhu/gorm.(*Scope).GetModelStruct()
      /work/gorm/model_struct.go:645 +0x206f
  github.com/jinzhu/gorm.(*Scope).GetStructFields()
      /work/gorm/model_struct.go:650 +0x3c
  github.com/jinzhu/gorm.(*Scope).GetModelStruct.func1()
      /work/gorm/model_struct.go:366 +0x1a79
  github.com/jinzhu/gorm.(*Scope).GetModelStruct()
      /work/gorm/model_struct.go:645 +0x206f
  github.com/jinzhu/gorm.(*Scope).GetStructFields()
      /work/gorm/model_struct.go:650 +0x3c
  github.com/jinzhu/gorm_test.TestModelStructRaceSameModel.func1()
      /work/gorm/model_struct_test.go:51 +0xe3

Goroutine 51 (running) created at:
  github.com/jinzhu/gorm_test.TestModelStructRaceSameModel()
      /work/gorm/model_struct_test.go:47 +0x10f
  testing.tRunner()
      /usr/local/Cellar/go/1.13/libexec/src/testing/testing.go:909 +0x199

Goroutine 42 (running) created at:
  github.com/jinzhu/gorm_test.TestModelStructRaceSameModel()
      /work/gorm/model_struct_test.go:47 +0x10f
  testing.tRunner()
      /usr/local/Cellar/go/1.13/libexec/src/testing/testing.go:909 +0x199
```