### PR TITLE
Better "Duplicate column name" handling

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -621,13 +621,20 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 	// look for field which has tag COLUMN assigned, if found any, set other fields which has the same DBName to IsIgnored = true
 	for _, v := range modelStruct.StructFields {
 		if column, ok := v.TagSettingsGet("COLUMN"); ok {
-			for _, field := range modelStruct.StructFields {
+			for k, field := range modelStruct.StructFields {
 				if field == v {
 					continue
 				}
 				if field.DBName == column {
-					field.IsIgnored = true
-					field.IsNormal = false
+					ignoredField := &StructField{
+						Struct:      field.Struct,
+						Name:        field.Name,
+						Names:       field.Names,
+						Tag:         field.Tag,
+						TagSettings: field.TagSettings,
+						IsIgnored:   true,
+					}
+					modelStruct.StructFields[k] = ignoredField
 				}
 			}
 		}

--- a/model_struct.go
+++ b/model_struct.go
@@ -617,6 +617,20 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 			modelStruct.StructFields = append(modelStruct.StructFields, field)
 		}
 	}
+	
+	// look for field which has tag COLUMN assigned, if found any, set other fields which has the same DBName to IsIgnored = true
+	for _, v := range modelStruct.StructFields {
+		if column, ok := v.TagSettingsGet("COLUMN"); ok {
+			for _, field := range modelStruct.StructFields {
+				if field == v {
+					continue
+				}
+				if field.DBName == column {
+					field.IsIgnored = true
+				}
+			}
+		}
+	}
 
 	if len(modelStruct.PrimaryFields) == 0 {
 		if field := getForeignField("id", modelStruct.StructFields); field != nil {

--- a/model_struct.go
+++ b/model_struct.go
@@ -627,6 +627,7 @@ func (scope *Scope) GetModelStruct() *ModelStruct {
 				}
 				if field.DBName == column {
 					field.IsIgnored = true
+					field.IsNormal = false
 				}
 			}
 		}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [ ] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

The original implementation of GORM cannot handle two fields with the same column name (DBName), even when one field has tag `gorm:"column:DBName"`, the other field will also get processed and appeared in the SQL statement.

This PR tried to solve the issue by if a field has a `DBName` assigned by struct tag `column`, then other fields that share the same `DBName` will be ignored automatically. 

This enables developers to embed an external struct and override fields with same name easily.

example usage:

```go
type User struct {
    gorm.Model
    ID int64 `gorm:"column:id"`
}
```
before applying this PR, there will be sql error of "Error 1060: Duplicate column name 'id'", with the PR applied, the `ID` column from gorm.Model will be ignored.
