### PR TITLE
Better "Duplicate column name" handling

### DIFF
--- a/model_struct_test.go
+++ b/model_struct_test.go
@@ -108,6 +108,6 @@ func TestModelStructIgnoreNoTagSameDBNameColumn(t *testing.T) {
 	}
 
 	if columnIDcount > 1 {
-		t.Fatal("fields have same name while contains no column tag not being ignored")
+		t.Fatal("fields that have same DBName, while containing no column tag are not being ignored")
 	}
 }

--- a/model_struct_test.go
+++ b/model_struct_test.go
@@ -91,3 +91,23 @@ func TestModelStructRaceDifferentModel(t *testing.T) {
 
 	done.Wait()
 }
+
+type ModelSameColumnName struct {
+	gorm.Model
+	ID string `gorm:"column:id"`
+}
+
+func TestModelStructIgnoreNoTagSameDBNameColumn(t *testing.T) {
+	sf := DB.NewScope(&ModelSameColumnName{}).GetStructFields()
+
+	columnIDcount := 0
+	for _, v := range sf {
+		if v.DBName == "id" {
+			columnIDcount++
+		}
+	}
+
+	if columnIDcount > 1 {
+		t.Fatal("fields have same name while contains no column tag not being ignored")
+	}
+}


### PR DESCRIPTION
struct fields with column tag will force other fields under same `DBName` with no column tag be ignored to avoid duplicated column name issue

Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

The original implementation of GORM cannot handle two fields with the same column name (DBName), even when one field has tag gorm:"column:DBName", the other field will also get processed and appeared in the SQL statement.

This PR tried to solve the issue by checking if a field has a DBName assigned by struct tag "column", if yes, then other fields that share the same DBName (while having no "column" tag will be ignored automatically.

This enables developers to embed an external struct and override fields with same name easily.

example usage:

```go
type User struct {
    gorm.Model
    ID int64 `gorm:"column:id"`
}
```

Before applying this PR, there will be sql error of "Error 1060: Duplicate column name 'id'".

After applying this PR, GORM will ignore the ID field inside `gorm.Model`. 

This PR might resolve https://github.com/jinzhu/gorm/issues/1504


---

P.s. This PR MIGHT be API-breaking as I am changing the behavior of modeling struct. Feel free to close this PR if a new Issue is required to discuss the implementation.