### PR TITLE
transaction blocks: don't swallow panics

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -470,6 +470,15 @@ func TestTransaction(t *testing.T) {
 	}
 }
 
+func assertPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	f()
+}
+
 func TestTransactionWithBlock(t *testing.T) {
 	// rollback
 	err := DB.Transaction(func(tx *gorm.DB) error {
@@ -511,17 +520,19 @@ func TestTransactionWithBlock(t *testing.T) {
 	}
 
 	// panic will rollback
-	DB.Transaction(func(tx *gorm.DB) error {
-		u3 := User{Name: "transcation-3"}
-		if err := tx.Save(&u3).Error; err != nil {
-			t.Errorf("No error should raise")
-		}
+	assertPanic(t, func() {
+		DB.Transaction(func(tx *gorm.DB) error {
+			u3 := User{Name: "transcation-3"}
+			if err := tx.Save(&u3).Error; err != nil {
+				t.Errorf("No error should raise")
+			}
 
-		if err := tx.First(&User{}, "name = ?", "transcation-3").Error; err != nil {
-			t.Errorf("Should find saved record")
-		}
+			if err := tx.First(&User{}, "name = ?", "transcation-3").Error; err != nil {
+				t.Errorf("Should find saved record")
+			}
 
-		panic("force panic")
+			panic("force panic")
+		})
 	})
 
 	if err := DB.First(&User{}, "name = ?", "transcation").Error; err == nil {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

This improves upon #2767.

Previously, the code would swallow any panics, which isn't ideal;
panic is intended to be used when a critical error arises,
where the process should fail fast instead of trying to limp along.

This now defers the any recovery (if desired) to the client code.
