### PR TITLE
add: disable default logger color with NO_COLOR support.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -13,13 +13,18 @@ import (
 )
 
 const (
+	// RESET is the shell code to disable output color
 	RESET = "\033[0m"
-
-	CYAN    = "\033[36;1m"
+	// CYAN is the shell code for CYAN output color
+	CYAN = "\033[36;1m"
+	// MAGENTA is the shell code for MAGENTA output color
 	MAGENTA = "\033[35m"
-	RED     = "\033[36;31m"
+	// RED is the shell code for RED output color
+	RED = "\033[36;31m"
+	// REDBOLD is the shell code for REDBOLD output color
 	REDBOLD = "\033[31;1m"
-	YELLOW  = "\033[33m"
+	// YELLOW is the shell code for YELLOW output color
+	YELLOW = "\033[33m"
 )
 
 var (
@@ -43,6 +48,7 @@ func isPrintable(s string) bool {
 	return true
 }
 
+// NoColor checks for environment if color should be enabled
 func NoColor() bool {
 	// https://no-color.org/
 	return os.Getenv("NO_COLOR") != ""

--- a/logger.go
+++ b/logger.go
@@ -31,12 +31,12 @@ var (
 	defaultLogger            = Logger{log.New(os.Stdout, "\r\n", 0)}
 	sqlRegexp                = regexp.MustCompile(`\?`)
 	numericPlaceHolderRegexp = regexp.MustCompile(`\$\d+`)
-	reset                    = ""
-	cyan                     = ""
-	magenta                  = ""
-	red                      = ""
-	redBold                  = ""
-	yellow                   = ""
+	reset                    = RESET
+	cyan                     = CYAN
+	magenta                  = MAGENTA
+	red                      = RED
+	redBold                  = REDBOLD
+	yellow                   = YELLOW
 )
 
 func isPrintable(s string) bool {
@@ -54,6 +54,16 @@ func NoColor() bool {
 	return os.Getenv("NO_COLOR") != ""
 }
 
+// ResetColors reads consts colors for test cases
+func ResetColors() {
+	red = RED
+	cyan = CYAN
+	reset = RESET
+	yellow = YELLOW
+	redBold = REDBOLD
+	magenta = MAGENTA
+}
+
 // LogFormatter is a default logger with timestamps, sql error handling, loglevel and NO_COLOR support
 var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 	suppressColor := NoColor()
@@ -66,13 +76,6 @@ var LogFormatter = func(values ...interface{}) (messages []interface{}) {
 		yellow = ""
 		redBold = ""
 		magenta = ""
-	} else {
-		red = RED
-		cyan = CYAN
-		reset = RESET
-		yellow = YELLOW
-		redBold = REDBOLD
-		magenta = MAGENTA
 	}
 	if len(values) > 1 {
 		var (

--- a/logger_test.go
+++ b/logger_test.go
@@ -15,7 +15,7 @@ func TestNoColor(t *testing.T) {
 	l := gorm.Logger{log.New(os.Stdout, "\r\n", 0)}
 	l.Print("info", "[info] NO_COLOR log test")
 	os.Setenv("NO_COLOR", "")
-	gorm.NoColor()
+	gorm.ResetColors()
 }
 
 func TestSQLLog(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,24 @@
+package gorm_test
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jinzhu/gorm"
+)
+
+func TestNoColor(t *testing.T) {
+	os.Setenv("NO_COLOR", "1")
+	gorm.NoColor()
+	l := gorm.Logger{log.New(os.Stdout, "\r\n", 0)}
+	l.Print("info", "[info] NO_COLOR log test")
+	os.Setenv("NO_COLOR", "")
+	gorm.NoColor()
+}
+
+func TestSQLLog(t *testing.T) {
+	l := gorm.Logger{log.New(os.Stdout, "\r\n", 0)}
+	l.Print("sql", "SQL log test", time.Duration(9990000), "sql: log format test type ", []interface{}{"cover"}, int64(0))
+}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Add [NO_COLOR](https://no-color.org/) compliance to gorm.

When logging, search for the NO_COLOR environment variable. If its not empty, suppress the color from the formatter. Else, log with the usual colors.

Also, a bit of refactor was done to achieve the task simpler than rewritting a new formatter:
- Export colors to variables
- Using string templates in all prints as opposed to cat strings

This behavior can be tested as:

```shell
$ NO_COLOR= go test  # same as $ go test
PASS
ok  	github.com/jinzhu/gorm	26.724s
$ NO_COLOR=1 go test
PASS
ok  	github.com/jinzhu/gorm	26.760s
```