### PR TITLE
sqlite not support comment

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -131,7 +131,7 @@ var ParseFieldStructForDialect = func(field *StructField, dialect Dialect) (fiel
 		additionalType = additionalType + " DEFAULT " + value
 	}
 
-	if value, ok := field.TagSettingsGet("COMMENT"); ok {
+	if value, ok := field.TagSettingsGet("COMMENT"); ok && dialect.GetName() != "sqlite3" {
 		additionalType = additionalType + " COMMENT " + value
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -25,12 +25,12 @@ type Errors []error
 func IsRecordNotFoundError(err error) bool {
 	if errs, ok := err.(Errors); ok {
 		for _, err := range errs {
-			if err == ErrRecordNotFound {
+			if err.Error() == ErrRecordNotFound.Error() {
 				return true
 			}
 		}
 	}
-	return err == ErrRecordNotFound
+	return err.Error() == ErrRecordNotFound.Error()
 }
 
 // GetErrors gets all errors that have occurred and returns a slice of errors (Error type)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0
 	github.com/jinzhu/now v1.0.1
 	github.com/lib/pq v1.1.1
+	github.com/go-errors/errors v1.0.2
 	github.com/mattn/go-sqlite3 v2.0.1+incompatible
 	golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd // indirect
 	google.golang.org/appengine v1.4.0 // indirect

--- a/main.go
+++ b/main.go
@@ -620,7 +620,7 @@ func (s *DB) NewRecord(value interface{}) bool {
 // RecordNotFound check if returning ErrRecordNotFound error
 func (s *DB) RecordNotFound() bool {
 	for _, err := range s.GetErrors() {
-		if err == ErrRecordNotFound {
+		if err.Error() == ErrRecordNotFound.Error() {
 			return true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	goerr "github.com/go-errors/errors"
 	"reflect"
 	"strings"
 	"sync"
@@ -824,6 +825,15 @@ func (s *DB) AddError(err error) error {
 
 // GetErrors get happened errors from the db
 func (s *DB) GetErrors() []error {
+	errs := s.getErrors()
+	wrapperErrors := []error{}
+	for _, err := range errs {
+		wrapperErrors = append(wrapperErrors, goerr.New(err))
+	}
+	return wrapperErrors
+}
+
+func (s *DB) getErrors() []error {
 	if errs, ok := s.Error.(Errors); ok {
 		return errs
 	} else if s.Error != nil {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

in sqlite3, migrate sql clause does not support field comment, if dialect is sqlite3, do not parse `COMMENT`
