### PR TITLE
check if field kind is ptr to prevent panic

### DIFF
--- a/callback_query_preload.go
+++ b/callback_query_preload.go
@@ -394,8 +394,8 @@ func (scope *Scope) handleManyToManyPreload(field *Field, conditions []interface
 
 	for source, fields := range fieldsSourceMap {
 		for _, f := range fields {
-			//If not 0 this means Value is a pointer and we already added preloaded models to it
-			if f.Len() != 0 {
+			//If kind is Ptr this means Value is a pointer and we already added preloaded models to it
+			if f.Kind() == reflect.Ptr {
 				continue
 			}
 


### PR DESCRIPTION
check if field kind is ptr to prevent panic when using slice pointers

Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
when working with pointers to slices like:
```go
type Condition struct{
  ID uint64
  Jobs *[]Job `gorm:"many2many:job_conditions"`
}

type Job struct{
  ID uint64
  Conditions *[]Condition `gorm:"many2many:job_conditions"`
}

func main(){
// [...]
db.Preload("Conditions").Find(&jobs)
// [...]
}
```
there will be a panic("reflect.MakeSlice of non-slice type") in [callback_query_preload.go:398](https://github.com/jinzhu/gorm/blob/7180bd0f27d167f18c253c32d548c7de3adc6b0d/callback_query_preload.go#L398), because a pointer to a slice which is nil will not be interpreted as a pointer.

To fix this issue, i've changed to check if it is a pointer with "(reflect.Value).Kind()" to see if the field is a pointer.

Many thanks in advance and thank you for this awesome project.