### PR TITLE
Fix TestTransactionWithBlock panic case

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -535,7 +535,7 @@ func TestTransactionWithBlock(t *testing.T) {
 		})
 	})
 
-	if err := DB.First(&User{}, "name = ?", "transcation").Error; err == nil {
+	if err := DB.First(&User{}, "name = ?", "transcation-3").Error; err == nil {
 		t.Errorf("Should not find record after panic rollback")
 	}
 }


### PR DESCRIPTION
Panic will rollback case should use "transaction-3".

Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Fix TestTransactionWithBlock panic case