### PR TITLE
Fix has_many associations with embedded structs

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -399,7 +399,7 @@ func (scope *Scope) getModelStruct(rootScope *Scope, allFields []*StructField) *
 										} else {
 											// generate foreign keys from defined association foreign keys
 											for _, scopeFieldName := range associationForeignKeys {
-												if foreignField := getForeignField(scopeFieldName, modelStruct.StructFields); foreignField != nil {
+												if foreignField := getForeignField(scopeFieldName, allFields); foreignField != nil {
 													foreignKeys = append(foreignKeys, associationType+foreignField.Name)
 													associationForeignKeys = append(associationForeignKeys, foreignField.Name)
 												}
@@ -411,7 +411,7 @@ func (scope *Scope) getModelStruct(rootScope *Scope, allFields []*StructField) *
 											for _, foreignKey := range foreignKeys {
 												if strings.HasPrefix(foreignKey, associationType) {
 													associationForeignKey := strings.TrimPrefix(foreignKey, associationType)
-													if foreignField := getForeignField(associationForeignKey, modelStruct.StructFields); foreignField != nil {
+													if foreignField := getForeignField(associationForeignKey, allFields); foreignField != nil {
 														associationForeignKeys = append(associationForeignKeys, associationForeignKey)
 													}
 												}
@@ -507,7 +507,7 @@ func (scope *Scope) getModelStruct(rootScope *Scope, allFields []*StructField) *
 									} else {
 										// generate foreign keys form association foreign keys
 										for _, associationForeignKey := range tagAssociationForeignKeys {
-											if foreignField := getForeignField(associationForeignKey, modelStruct.StructFields); foreignField != nil {
+											if foreignField := getForeignField(associationForeignKey, allFields); foreignField != nil {
 												foreignKeys = append(foreignKeys, associationType+foreignField.Name)
 												associationForeignKeys = append(associationForeignKeys, foreignField.Name)
 											}
@@ -519,7 +519,7 @@ func (scope *Scope) getModelStruct(rootScope *Scope, allFields []*StructField) *
 										for _, foreignKey := range foreignKeys {
 											if strings.HasPrefix(foreignKey, associationType) {
 												associationForeignKey := strings.TrimPrefix(foreignKey, associationType)
-												if foreignField := getForeignField(associationForeignKey, modelStruct.StructFields); foreignField != nil {
+												if foreignField := getForeignField(associationForeignKey, allFields); foreignField != nil {
 													associationForeignKeys = append(associationForeignKeys, associationForeignKey)
 												}
 											}

--- a/model_struct.go
+++ b/model_struct.go
@@ -152,10 +152,10 @@ func getForeignField(column string, fields []*StructField) *StructField {
 
 // GetModelStruct get value's model struct, relationships based on struct and tag definition
 func (scope *Scope) GetModelStruct() *ModelStruct {
-	return scope.getModelStruct(make([]*StructField, 0))
+	return scope.getModelStruct(scope, make([]*StructField, 0))
 }
 
-func (scope *Scope) getModelStruct(allFields []*StructField) *ModelStruct {
+func (scope *Scope) getModelStruct(rootScope *Scope, allFields []*StructField) *ModelStruct {
 	var modelStruct ModelStruct
 	// Scope value can't be nil
 	if scope.Value == nil {
@@ -241,7 +241,7 @@ func (scope *Scope) getModelStruct(allFields []*StructField) *ModelStruct {
 					field.IsNormal = true
 				} else if _, ok := field.TagSettingsGet("EMBEDDED"); ok || fieldStruct.Anonymous {
 					// is embedded struct
-					for _, subField := range scope.New(fieldValue).getModelStruct(allFields).StructFields {
+					for _, subField := range scope.New(fieldValue).getModelStruct(rootScope, allFields).StructFields {
 						subField = subField.clone()
 						subField.Names = append([]string{fieldStruct.Name}, subField.Names...)
 						if prefix, ok := field.TagSettingsGet("EMBEDDED_PREFIX"); ok {
@@ -417,7 +417,7 @@ func (scope *Scope) getModelStruct(allFields []*StructField) *ModelStruct {
 												}
 											}
 											if len(associationForeignKeys) == 0 && len(foreignKeys) == 1 {
-												associationForeignKeys = []string{scope.PrimaryKey()}
+												associationForeignKeys = []string{rootScope.PrimaryKey()}
 											}
 										} else if len(foreignKeys) != len(associationForeignKeys) {
 											scope.Err(errors.New("invalid foreign keys, should have same length"))
@@ -525,7 +525,7 @@ func (scope *Scope) getModelStruct(allFields []*StructField) *ModelStruct {
 											}
 										}
 										if len(associationForeignKeys) == 0 && len(foreignKeys) == 1 {
-											associationForeignKeys = []string{scope.PrimaryKey()}
+											associationForeignKeys = []string{rootScope.PrimaryKey()}
 										}
 									} else if len(foreignKeys) != len(associationForeignKeys) {
 										scope.Err(errors.New("invalid foreign keys, should have same length"))

--- a/model_struct_test.go
+++ b/model_struct_test.go
@@ -31,12 +31,12 @@ type ModelC struct {
 	OtherB   *ModelB `gorm:"foreignkey:OtherBID"`
 }
 
-type Request struct {
+type RequestModel struct {
 	Name     string
-	Children []Child `gorm:"foreignkey:ParentID"`
+	Children []ChildModel `gorm:"foreignkey:ParentID"`
 }
 
-type Child struct {
+type ChildModel struct {
 	ID       string
 	ParentID string
 	Name     string
@@ -44,7 +44,7 @@ type Child struct {
 
 type ResponseModel struct {
 	gorm.Model
-	Request
+	RequestModel
 }
 
 // This test will try to cause a race condition on the model's foreignkey metadata

--- a/model_struct_test.go
+++ b/model_struct_test.go
@@ -31,6 +31,22 @@ type ModelC struct {
 	OtherB   *ModelB `gorm:"foreignkey:OtherBID"`
 }
 
+type Request struct {
+	Name     string
+	Children []Child `gorm:"foreignkey:ParentID;association_foreignkey:ID"`
+}
+
+type Child struct {
+	ID       string
+	ParentID string
+	Name     string
+}
+
+type ResponseModel struct {
+	gorm.Model
+	Request
+}
+
 // This test will try to cause a race condition on the model's foreignkey metadata
 func TestModelStructRaceSameModel(t *testing.T) {
 	// use a WaitGroup to execute as much in-sync as possible
@@ -90,4 +106,35 @@ func TestModelStructRaceDifferentModel(t *testing.T) {
 	}
 
 	done.Wait()
+}
+
+func TestModelStructEmbeddedHasMany(t *testing.T) {
+	fields := DB.NewScope(&ResponseModel{}).GetStructFields()
+
+	var childrenField *gorm.StructField
+
+	for i := 0; i < len(fields); i++ {
+		field := fields[i]
+
+		if field != nil && field.Name == "Children" {
+			childrenField = field
+		}
+	}
+
+	if childrenField == nil {
+		t.Error("childrenField should not be nil")
+		return
+	}
+
+	if childrenField.Relationship == nil {
+		t.Error("childrenField.Relation should not be nil")
+		return
+	}
+
+	expected := "has_many"
+	actual := childrenField.Relationship.Kind
+
+	if actual != expected {
+		t.Errorf("childrenField.Relationship.Kind should be %v, but was %v", expected, actual)
+	}
 }

--- a/model_struct_test.go
+++ b/model_struct_test.go
@@ -33,7 +33,7 @@ type ModelC struct {
 
 type Request struct {
 	Name     string
-	Children []Child `gorm:"foreignkey:ParentID;association_foreignkey:ID"`
+	Children []Child `gorm:"foreignkey:ParentID"`
 }
 
 type Child struct {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
When the `association_foreign_key` is in a "cousin" struct, not at a level above, the association is not detected.  The unit test that was added recreates this scenario, and is a good resource for more information. This was fixed by providing additional data to the `GetModelStruct` function when called recursively for embedded structs.