### PR TITLE
Prevent nested transactions with *DB.Transaction

### DIFF
--- a/main.go
+++ b/main.go
@@ -531,6 +531,11 @@ func (s *DB) Debug() *DB {
 // Transaction start a transaction as a block,
 // return error will rollback, otherwise to commit.
 func (s *DB) Transaction(fc func(tx *DB) error) (err error) {
+
+	if _, ok := s.db.(*sql.Tx); ok {
+		return fc(s)
+	}
+
 	panicked := true
 	tx := s.Begin()
 	defer func() {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

### What did this pull request do?
This will prevent creating nested transactions while calling *DB.Transaction(...) multiple times.
Only fist call will create transaction. Rest will just reuse it.