### PR TITLE
Enhance gorm to specify the table to search.

### DIFF
--- a/main.go
+++ b/main.go
@@ -519,7 +519,7 @@ func (s *DB) Model(value interface{}) *DB {
 func (s *gorm.DB) SetTable(name interface{}) *DB {
 	clone := s.clone()
 	snake := fmt.Sprint(reflect.TypeOf(name).Elem().Name() + "s")
-	clone.search.Table(sqlUtils.ToSnakeCase(snake))
+	clone.search.Table(ToSnakeCase(snake))
 	clone.Value = nil
 	return clone
 }

--- a/main.go
+++ b/main.go
@@ -515,6 +515,24 @@ func (s *DB) Model(value interface{}) *DB {
 	return c
 }
 
+// SetTable specify the table you would like to run db operations, using the object struct's name.
+func (s *gorm.DB) SetTable(name interface{}) *DB {
+	clone := s.clone()
+	snake := fmt.Sprint(reflect.TypeOf(name).Elem().Name() + "s")
+	clone.search.Table(sqlUtils.ToSnakeCase(snake))
+	clone.Value = nil
+	return clone
+}
+
+// ToSnakeCase change string to snake form.
+func ToSnakeCase(str string) string {
+	var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
 // Table specify the table you would like to run db operations
 func (s *DB) Table(name string) *DB {
 	clone := s.clone()


### PR DESCRIPTION
Enhance gorm to specify the table to search.
Enable query syntax as following syntax

```
type DataObj struct {
	ID            int    `json:"id" gorm:"primary_key"`
	Data      string `json:"string"`
}
dataObj := DataObj{}
rep.db.Debug().SetTable(&dataObj).Where("id = ?", 64).Scan(&dataObj)
```

--- Result SQL
```
SELECT * FROM "data_objs"  WHERE (id = 64)  
```

Make sure these boxes checked before submitting your pull request.

- [] Do only one thing
- [] No API-breaking changes
- [] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
