### PR TITLE
feature: ignore limite and offset query with count

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -586,6 +586,14 @@ func TestCount(t *testing.T) {
 	if count3 != 2 {
 		t.Errorf("Should get correct count, but got %v", count3)
 	}
+
+	if err := DB.Model(&User{}).Limit(1).Offset(2).Count(&count).Error; err != nil {
+		t.Errorf("Not error should happen, but got %v", err)
+	}
+
+	if count != 2 {
+		t.Errorf("Should get correct count, but got %v", count)
+	}
 }
 
 func TestNot(t *testing.T) {

--- a/scope.go
+++ b/scope.go
@@ -797,6 +797,10 @@ func (scope *Scope) orderSQL() string {
 }
 
 func (scope *Scope) limitAndOffsetSQL() string {
+	if scope.Search.ignoreLimitAndOffsetQuery {
+		return ""
+	}
+
 	sql, err := scope.Dialect().LimitAndOffsetSQL(scope.Search.limit, scope.Search.offset)
 	scope.Err(err)
 	return sql
@@ -1031,6 +1035,7 @@ func (scope *Scope) count(value interface{}) *Scope {
 		}
 	}
 	scope.Search.ignoreOrderQuery = true
+	scope.Search.ignoreLimitAndOffsetQuery = true
 	scope.Err(scope.row().Scan(value))
 	return scope
 }

--- a/search.go
+++ b/search.go
@@ -5,25 +5,26 @@ import (
 )
 
 type search struct {
-	db               *DB
-	whereConditions  []map[string]interface{}
-	orConditions     []map[string]interface{}
-	notConditions    []map[string]interface{}
-	havingConditions []map[string]interface{}
-	joinConditions   []map[string]interface{}
-	initAttrs        []interface{}
-	assignAttrs      []interface{}
-	selects          map[string]interface{}
-	omits            []string
-	orders           []interface{}
-	preload          []searchPreload
-	offset           interface{}
-	limit            interface{}
-	group            string
-	tableName        string
-	raw              bool
-	Unscoped         bool
-	ignoreOrderQuery bool
+	db                        *DB
+	whereConditions           []map[string]interface{}
+	orConditions              []map[string]interface{}
+	notConditions             []map[string]interface{}
+	havingConditions          []map[string]interface{}
+	joinConditions            []map[string]interface{}
+	initAttrs                 []interface{}
+	assignAttrs               []interface{}
+	selects                   map[string]interface{}
+	omits                     []string
+	orders                    []interface{}
+	preload                   []searchPreload
+	offset                    interface{}
+	limit                     interface{}
+	group                     string
+	tableName                 string
+	raw                       bool
+	Unscoped                  bool
+	ignoreOrderQuery          bool
+	ignoreLimitAndOffsetQuery bool
 }
 
 type searchPreload struct {
@@ -33,25 +34,26 @@ type searchPreload struct {
 
 func (s *search) clone() *search {
 	clone := search{
-		db:               s.db,
-		whereConditions:  make([]map[string]interface{}, len(s.whereConditions)),
-		orConditions:     make([]map[string]interface{}, len(s.orConditions)),
-		notConditions:    make([]map[string]interface{}, len(s.notConditions)),
-		havingConditions: make([]map[string]interface{}, len(s.havingConditions)),
-		joinConditions:   make([]map[string]interface{}, len(s.joinConditions)),
-		initAttrs:        make([]interface{}, len(s.initAttrs)),
-		assignAttrs:      make([]interface{}, len(s.assignAttrs)),
-		selects:          s.selects,
-		omits:            make([]string, len(s.omits)),
-		orders:           make([]interface{}, len(s.orders)),
-		preload:          make([]searchPreload, len(s.preload)),
-		offset:           s.offset,
-		limit:            s.limit,
-		group:            s.group,
-		tableName:        s.tableName,
-		raw:              s.raw,
-		Unscoped:         s.Unscoped,
-		ignoreOrderQuery: s.ignoreOrderQuery,
+		db:                        s.db,
+		whereConditions:           make([]map[string]interface{}, len(s.whereConditions)),
+		orConditions:              make([]map[string]interface{}, len(s.orConditions)),
+		notConditions:             make([]map[string]interface{}, len(s.notConditions)),
+		havingConditions:          make([]map[string]interface{}, len(s.havingConditions)),
+		joinConditions:            make([]map[string]interface{}, len(s.joinConditions)),
+		initAttrs:                 make([]interface{}, len(s.initAttrs)),
+		assignAttrs:               make([]interface{}, len(s.assignAttrs)),
+		selects:                   s.selects,
+		omits:                     make([]string, len(s.omits)),
+		orders:                    make([]interface{}, len(s.orders)),
+		preload:                   make([]searchPreload, len(s.preload)),
+		offset:                    s.offset,
+		limit:                     s.limit,
+		group:                     s.group,
+		tableName:                 s.tableName,
+		raw:                       s.raw,
+		Unscoped:                  s.Unscoped,
+		ignoreOrderQuery:          s.ignoreOrderQuery,
+		ignoreLimitAndOffsetQuery: s.ignoreLimitAndOffsetQuery,
 	}
 	for i, value := range s.whereConditions {
 		clone.whereConditions[i] = value


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

Sometime we want to paginate convenient, we will write like below,but we will get an error: 

```golang
var (
    user := []User
    count int
)

if err := DB.Where("name=?", "john").Limit(10).Offset(20).Find(&users).Count(&count).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
 }
```

It is because if we run `Count` with `Offset`, we will get an empty data set.

After my attempts, this can achieve the goal

```golang
var (
    user := []User
    count int
)

db := DB.Where("name=?", "john")
if err := db.Limit(10).Offset(20).Find(&users).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
 }

if err := db.Count(&count).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
 }
```

or


```golang
var (
    user := []User
    count int
)

if err := DB.Where("name=?", "john").Limit(10).Offset(20).Find(&users).Offset(0).Count(&count).Error; err != nil {
       t.Errorf("Not error should happen, but got %v", err)
 }
```
**But the code will be more verbose. I think more people hope to complete the goal in one chain call, like** [here](https://jasperxu.github.io/gorm-zh/crud.html#count)

This branch is ported from [ignoreOrderQuery](https://github.com/jinzhu/gorm/blob/master/scope.go#L1033), use a new tag ignoreLimitAndOffsetQuery to skip the `limitAndOffsetQuery`
