### PR TITLE
Respect gorm:query_option in SubQuery() & QueryExpr() methods

### DIFF
--- a/callback_query.go
+++ b/callback_query.go
@@ -65,10 +65,6 @@ func queryCallback(scope *Scope) {
 			scope.SQL = fmt.Sprint(str) + scope.SQL
 		}
 
-		if str, ok := scope.Get("gorm:query_option"); ok {
-			scope.SQL += addExtraSpaceIfExist(fmt.Sprint(str))
-		}
-
 		if rows, err := scope.SQLDB().Query(scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
 			defer rows.Close()
 

--- a/callback_row_query.go
+++ b/callback_row_query.go
@@ -28,10 +28,6 @@ func rowQueryCallback(scope *Scope) {
 			scope.SQL = fmt.Sprint(str) + scope.SQL
 		}
 
-		if str, ok := scope.Get("gorm:query_option"); ok {
-			scope.SQL += addExtraSpaceIfExist(fmt.Sprint(str))
-		}
-
 		if rowResult, ok := result.(*RowQueryResult); ok {
 			rowResult.Row = scope.SQLDB().QueryRow(scope.SQL, scope.SQLVars...)
 		} else if rowsResult, ok := result.(*RowsQueryResult); ok {

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1336,6 +1337,34 @@ func TestCountWithQueryOption(t *testing.T) {
 
 	if count != 1 {
 		t.Error("Unexpected result on query count with query_option")
+	}
+}
+
+func TestSubQueryWithQueryOption(t *testing.T) {
+	db := DB.New()
+
+	subQuery := db.Model(User{}).Select("users.id").
+		Set("gorm:query_option", "WHERE users.name='user2'").
+		SubQuery()
+
+	matched, _ := regexp.MatchString(
+		`^&{.+\s+WHERE users\.name='user2'.*\s\[]}$`, fmt.Sprint(subQuery))
+	if !matched {
+		t.Error("Unexpected result of SubQuery with query_option")
+	}
+}
+
+func TestQueryExprWithQueryOption(t *testing.T) {
+	db := DB.New()
+
+	queryExpr := db.Model(User{}).Select("users.id").
+		Set("gorm:query_option", "WHERE users.name='user2'").
+		QueryExpr()
+
+	matched, _ := regexp.MatchString(
+		`^&{.+\s+WHERE users\.name='user2'.*\s\[]}$`, fmt.Sprint(queryExpr))
+	if !matched {
+		t.Error("Unexpected result of QueryExpr with query_option")
 	}
 }
 

--- a/scope.go
+++ b/scope.go
@@ -841,12 +841,16 @@ func (scope *Scope) joinsSQL() string {
 }
 
 func (scope *Scope) prepareQuerySQL() {
+	var sql string
 	if scope.Search.raw {
-		scope.Raw(scope.CombinedConditionSql())
+		sql = scope.CombinedConditionSql()
 	} else {
-		scope.Raw(fmt.Sprintf("SELECT %v FROM %v %v", scope.selectSQL(), scope.QuotedTableName(), scope.CombinedConditionSql()))
+		sql = fmt.Sprintf("SELECT %v FROM %v %v", scope.selectSQL(), scope.QuotedTableName(), scope.CombinedConditionSql())
 	}
-	return
+	if str, ok := scope.Get("gorm:query_option"); ok {
+		sql += addExtraSpaceIfExist(fmt.Sprint(str))
+	}
+	scope.Raw(sql)
 }
 
 func (scope *Scope) inlineCondition(values ...interface{}) *Scope {


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Currently SubQuery() & QueryExpr() ignore 'gorm:query_option' which is wrong and causes sub-selects to lose locking. The patch eliminates the issue.