### PR TITLE
Clone the Default logger when opening

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,6 +85,9 @@ func Open(dialect string, args ...interface{}) (db *DB, err error) {
 	db = &DB{
 		db:        dbSQL,
 		logger:    defaultLogger,
+		
+		// Create a clone of the default logger to avoid mutating a shared object when
+		// multiple gorm connections are created simultaneously.
 		callbacks: DefaultCallback.clone(defaultLogger),
 		dialect:   newDialect(dialect, dbSQL),
 	}

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func Open(dialect string, args ...interface{}) (db *DB, err error) {
 	db = &DB{
 		db:        dbSQL,
 		logger:    defaultLogger,
-		callbacks: DefaultCallback,
+		callbacks: DefaultCallback.clone(defaultLogger),
 		dialect:   newDialect(dialect, dbSQL),
 	}
 	db.parent = db


### PR DESCRIPTION
- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented ~& tested~

### What did this pull request do?

This fixes a data race when multiple gorm connections are being created simultaneously. I don't really have a good way to test this.