### PR TITLE
add custom flag gorm:custom_transaction to bypass transaction from De…

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -401,6 +401,9 @@ func (scope *Scope) InstanceGet(name string) (interface{}, bool) {
 
 // Begin start a transaction
 func (scope *Scope) Begin() *Scope {
+	if _, ok := scope.InstanceGet("gorm:custom_transaction"); ok {
+		return scope
+	}
 	if db, ok := scope.SQLDB().(sqlDb); ok {
 		if tx, err := db.Begin(); scope.Err(err) == nil {
 			scope.db.db = interface{}(tx).(SQLCommon)
@@ -412,6 +415,9 @@ func (scope *Scope) Begin() *Scope {
 
 // CommitOrRollback commit current transaction if no error happened, otherwise will rollback it
 func (scope *Scope) CommitOrRollback() *Scope {
+	if _, ok := scope.InstanceGet("gorm:custom_transaction"); ok {
+		return scope
+	}
 	if _, ok := scope.InstanceGet("gorm:started_transaction"); ok {
 		if db, ok := scope.db.db.(sqlTx); ok {
 			if scope.HasError() {


### PR DESCRIPTION
…faultHandler

Make sure these boxes checked before submitting your pull request.

- [*] Do only one thing
- [*] No API-breaking changes
- [*] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

This PR is to add a setting to enable application developer to control when GORM should do things for them in GORM transactions.

For details, the PR adds a new setting named `gorm:custom_transaction`.  The application developer could set it before call any GORM API. As DefaultHandler has most CUD callbacks with transaction started automatically, the new logic will check `gorm:custom_transaction` firstly before do transaction things.

This feature can help application developer do their things at their demands easily and do not need to do the global setting or develop a customized callback plugin to do this. It is more convenient to use this setting.

Please kindly help review this PR. 

Thanks.