### PR TITLE
[fix] full table scan when `INSERT IGNORE` with duplicated record

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -176,12 +176,19 @@ func createCallback(scope *Scope) {
 // forceReloadAfterCreateCallback will reload columns that having default value, and set it back to current object
 func forceReloadAfterCreateCallback(scope *Scope) {
 	if blankColumnsWithDefaultValue, ok := scope.InstanceGet("gorm:blank_columns_with_default_value"); ok {
+		var shouldScan bool
 		db := scope.DB().New().Table(scope.TableName()).Select(blankColumnsWithDefaultValue.([]string))
 		for _, field := range scope.Fields() {
 			if field.IsPrimaryKey && !field.IsBlank {
 				db = db.Where(fmt.Sprintf("%v = ?", field.DBName), field.Field.Interface())
+				shouldScan = true
 			}
 		}
+
+		if !shouldScan {
+			return
+		}
+
 		db.Scan(scope.Value)
 	}
 }

--- a/migration_test.go
+++ b/migration_test.go
@@ -283,6 +283,11 @@ func getPreparedUser(name string, role string) *User {
 	}
 }
 
+type Panda struct {
+    Number int64 `gorm:"unique_index:number"`
+    Name string `gorm:"column:name;type:varchar(255);default:null"`
+}
+
 func runMigration() {
 	if err := DB.DropTableIfExists(&User{}).Error; err != nil {
 		fmt.Printf("Got error when try to delete table users, %+v\n", err)
@@ -292,7 +297,7 @@ func runMigration() {
 		DB.Exec(fmt.Sprintf("drop table %v;", table))
 	}
 
-	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}, &Place{}}
+	values := []interface{}{&Short{}, &ReallyLongThingThatReferencesShort{}, &ReallyLongTableNameToTestMySQLNameLengthLimit{}, &NotSoLongTableName{}, &Product{}, &Email{}, &Address{}, &CreditCard{}, &Company{}, &Role{}, &Language{}, &HNPost{}, &EngadgetPost{}, &Animal{}, &User{}, &JoinTable{}, &Post{}, &Category{}, &Comment{}, &Cat{}, &Dog{}, &Hamster{}, &Toy{}, &ElementWithIgnoredField{}, &Place{}, &Panda{}}
 	for _, value := range values {
 		DB.DropTable(value)
 	}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Fix the whole table query when using `Set("gorm:insert_modifier", "IGNORE")` for `INSERT`, while the table has columns with `default:sth` tag and the db has duplicated record.
