### PR TITLE
Fix lack of error passing for nested preload

### DIFF
--- a/callback_query_preload.go
+++ b/callback_query_preload.go
@@ -73,12 +73,14 @@ func preloadCallback(scope *Scope) {
 						scope.Err(errors.New("unsupported relation"))
 					}
 
-					preloadedMap[preloadKey] = true
+					if currentScope.DB().Error == nil {
+						preloadedMap[preloadKey] = true
+					}
 					break
 				}
 
 				if !preloadedMap[preloadKey] {
-					scope.Err(fmt.Errorf("can't preload field %s for %s", preloadField, currentScope.GetModelStruct().ModelType))
+					scope.Err(fmt.Errorf("can't preload field %s for %s: %s", preloadField, currentScope.GetModelStruct().ModelType, currentScope.DB().Error))
 					return
 				}
 			}

--- a/preload_test.go
+++ b/preload_test.go
@@ -3,8 +3,10 @@ package gorm_test
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jinzhu/gorm"
@@ -189,6 +191,108 @@ func TestNestedPreload1(t *testing.T) {
 
 	if err := DB.Preload("Level2").Preload("Level2.Level1").Find(&got, "name = ?", "not_found").Error; err != gorm.ErrRecordNotFound {
 		t.Error(err)
+	}
+}
+
+type SQLCommonMock struct {
+	db         *sql.DB
+	errorQuery string
+}
+
+func (s *SQLCommonMock) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return s.db.Exec(query, args...)
+}
+
+func (s *SQLCommonMock) Prepare(query string) (*sql.Stmt, error) {
+	return s.db.Prepare(query)
+}
+
+func (s *SQLCommonMock) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	if query == s.errorQuery {
+		return nil, errors.New("faked database error")
+	}
+	return s.db.Query(query, args...)
+}
+
+func (s *SQLCommonMock) QueryRow(query string, args ...interface{}) *sql.Row {
+	return s.db.QueryRow(query, args...)
+}
+
+func TestNestedPreload1FirstLevelError(t *testing.T) {
+	var err error
+	sqlDB := DB.DB()
+
+	// will not preload Level2 due to faked database error
+	sqlMock := &SQLCommonMock{db: sqlDB, errorQuery: `SELECT * FROM "level2"  WHERE ("level3_id" IN (?))`}
+	localDB, err := gorm.Open(DB.Dialect().GetName(), sqlMock)
+	if err != nil {
+		t.Error(err)
+	}
+
+	type (
+		Level1 struct {
+			ID       uint
+			Value    string
+			Level2ID uint
+		}
+		Level2 struct {
+			ID       uint
+			Level1   Level1
+			Level3ID uint
+		}
+		Level3 struct {
+			ID     uint
+			Name   string
+			Level2 Level2
+		}
+	)
+	localDB.DropTableIfExists(&Level3{})
+	localDB.DropTableIfExists(&Level2{})
+	localDB.DropTableIfExists(&Level1{})
+	if err := localDB.AutoMigrate(&Level3{}, &Level2{}, &Level1{}).Error; err != nil {
+		t.Error(err)
+	}
+
+	savedToDb := Level3{Level2: Level2{Level1: Level1{Value: "value"}}}
+	if err = localDB.Create(&savedToDb).Error; err != nil {
+		t.Error(err)
+	}
+
+	want := savedToDb
+	want.Level2 = Level2{}
+
+	var got Level3
+	if err = localDB.Preload("Level2").Find(&got).Error; errors.Is(err, nil) {
+		t.Error("expecting error on preload failue")
+	}
+
+	if err != nil && !strings.Contains(err.Error(), "faked database error") {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %s; want %s", toJSONString(got), toJSONString(want))
+	}
+
+	// will not preload Level1 due to faked database error
+	sqlMock = &SQLCommonMock{db: sqlDB, errorQuery: `SELECT * FROM "level1"  WHERE ("level2_id" IN (?))`}
+	localDB, err = gorm.Open(DB.Dialect().GetName(), sqlMock)
+	if err != nil {
+		t.Error(err)
+	}
+
+	want = savedToDb
+	want.Level2.Level1 = Level1{}
+	if err = localDB.Preload("Level2.Level1").Find(&got).Error; errors.Is(err, nil) {
+		t.Error("expecting error on nested preload failue")
+	}
+
+	if err != nil && !strings.Contains(err.Error(), "faked database error") {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %s; want %s", toJSONString(got), toJSONString(want))
 	}
 }
 


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
For nested preloads there seems to be no passing of errors if a preload query fails. So for example in a test case from this PR, if `Level2` preload fails with error for `err = localDB.Preload("Level2").Find(&got).Error`, then `err != nil`. 

However, for nested preload fails this is not the case. If `Level1` preload will fail with error from the DB, for the `err = localDB.Preload("Level2.Level1").Find(&got).Error` query we will have `err == nil`. This may lead to segmentation faults when objects that are expected to be preloaded (because `err == nil`) are in fact not preloaded and empty.

This PR fixes that by checking `currentScope` errors on preload callbacks.